### PR TITLE
Fix for early destroyed resources #173

### DIFF
--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/logic/network/JsonTransferer.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/logic/network/JsonTransferer.java
@@ -11,8 +11,6 @@ import nl.tudelft.watchdog.ui.util.UIUtils;
 import nl.tudelft.watchdog.ui.wizards.Project;
 import nl.tudelft.watchdog.ui.wizards.User;
 
-import org.apache.http.HttpEntity;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -91,9 +89,8 @@ public class JsonTransferer {
 	public String registerNew(String postURL, String json)
 			throws ServerCommunicationException {
 		try {
-			HttpEntity inputStream = NetworkUtils.transferJsonAndGetResponse(
+			String jsonResponse = NetworkUtils.transferJsonAndGetResponse(
 					postURL, json);
-			String jsonResponse = NetworkUtils.readResponse(inputStream);
 			return gson.fromJson(jsonResponse, String.class);
 		} catch (ServerReturnCodeException exception) {
 			throw new ServerCommunicationException(exception.getMessage());
@@ -107,8 +104,7 @@ public class JsonTransferer {
 	 */
 	public String queryGetURL(String getURL)
 			throws ServerCommunicationException {
-		HttpEntity inputStream = NetworkUtils.getURLAndGetResponse(getURL);
-		String jsonResponse = NetworkUtils.readResponse(inputStream);
+		String jsonResponse = NetworkUtils.getURLAndGetResponse(getURL);
 		try {
 			String response = gson.fromJson(jsonResponse, String.class);
 

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/logic/network/NetworkUtils.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/logic/network/NetworkUtils.java
@@ -39,11 +39,11 @@ public class NetworkUtils {
 	};
 
 	/**
-	 * Returns the content at the given URL.
+	 * Returns the String content at the given URL.
 	 * 
 	 * @throws ServerCommunicationException
 	 */
-	public static HttpEntity getURLAndGetResponse(String url)
+	public static String getURLAndGetResponse(String url)
 			throws ServerCommunicationException {
 		CloseableHttpClient client = createHTTPClient();
 		HttpGet get;
@@ -54,7 +54,8 @@ public class NetworkUtils {
 			HttpResponse response = client.execute(get);
 			int statusCode = response.getStatusLine().getStatusCode();
 			if (statusCode == HttpStatus.SC_OK) {
-				return response.getEntity();
+				String jsonResponse = readResponse(response.getEntity());
+				return jsonResponse;
 			} else {
 				errorMessage = "Not received " + HttpStatus.SC_OK;
 			}
@@ -111,13 +112,12 @@ public class NetworkUtils {
 	 * Opens an HTTP connection to the server, and transmits the supplied json
 	 * data to the server. In case of error, the exact problem is logged.
 	 * 
-	 * @return The InputStream from the response.
+	 * @return The json string from the response.
 	 * @throws ServerCommunicationException
 	 * @throws ServerReturnCodeException
 	 */
-	public static HttpEntity transferJsonAndGetResponse(String url,
-			String jsonData) throws ServerCommunicationException,
-			ServerReturnCodeException {
+	public static String transferJsonAndGetResponse(String url, String jsonData)
+			throws ServerCommunicationException, ServerReturnCodeException {
 		CloseableHttpClient client = createHTTPClient();
 		HttpPost post = new HttpPost(url);
 		String errorMessage = "";
@@ -132,7 +132,8 @@ public class NetworkUtils {
 
 			HttpResponse response = client.execute(post);
 			if (response.getStatusLine().getStatusCode() == HttpStatus.SC_CREATED) {
-				return response.getEntity();
+				String jsonResponse = readResponse(response.getEntity());
+				return jsonResponse;
 			} else {
 				// server returns not created
 				throw new ServerReturnCodeException(

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/logic/ui/EventManager.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/logic/ui/EventManager.java
@@ -78,7 +78,6 @@ public class EventManager {
 
 		case END_ECLIPSE:
 			userInactivityNotifier.cancelTimer(forcedDate);
-			intervalManager.closeAllIntervals();
 			break;
 
 		case ACTIVE_WINDOW:

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/ui/handlers/StartupHandler.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/ui/handlers/StartupHandler.java
@@ -30,10 +30,10 @@ public class StartupHandler implements IStartup {
 		try {
 			WatchDogLogger.getInstance().logInfo("Starting WatchDog ...");
 
+			WatchDogGlobals.hostIDE = IDE.ECLIPSE;
 			// Initialize the interval manager, and thereby, interval recording.
 			InitializationManager.getInstance();
 			WatchDogGlobals.isActive = true;
-			WatchDogGlobals.hostIDE = IDE.ECLIPSE;
 			// Update WatchDog icon
 			UIUtils.refreshCommand(UIUtils.COMMAND_SHOW_INFO);
 			updateView();


### PR DESCRIPTION
HttpResponse was deleted (closed) before HttpEntity has been returned (in `finally` block).  This bug resulted in incomplete user/project registrations.

Fixed by putting complete HttpResponse-reading logic in NetworkUtils class. JsonTransfer now only operates with Strings. 