### PR TITLE
Fix for missed IntelliJ14 JUnit executions.

### DIFF
--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/logic/interval/intervaltypes/JUnitExecution.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/logic/interval/intervaltypes/JUnitExecution.java
@@ -74,8 +74,16 @@ public class JUnitExecution extends JUnitExecutionBase {
         if (testProxy.isLeaf()) {
             // Test case (test method)
             String[] testNames = testProxy.getName().split(Pattern.quote("."));
-            parent.setClassNameHash(testNames[0]);
-            testMethodHash = WatchDogUtils.createHash(testNames[1]);
+
+            if (testNames.length > 1) {
+                // IntelliJ15 compatible call
+                parent.setClassNameHash(testNames[0]);
+                testMethodHash = WatchDogUtils.createHash(testNames[1]);
+            } else {
+                // IntelliJ14 compatible call
+                parent.setClassNameHash(testProxy.getParent().getName());
+                testMethodHash = WatchDogUtils.createHash(testProxy.getName());
+            }
         } else {
             // Test container (test class with test methods)
             childrenExecutions = createTree(testProxy);


### PR DESCRIPTION
@Inventitech I think this was the issue with missed intervals: `testProxy.getName()` in IJ14 returns just a test name, and in IJ15 it returns fully qualified name. In IJ14, testNames[1] caused NPE because of that.