### PR TITLE
Reduce the shutdown time in case of a network error

### DIFF
--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalTransferManagerBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalTransferManagerBase.java
@@ -35,14 +35,11 @@ public class IntervalTransferManagerBase extends RegularCheckerBase {
 		runSetupAndStartTimeChecker();
 	}
 
-	/** 
-	 * Immediately synchronizes the intervals with the server. 
-	 * This function is only called before shutting down the IDE and it first 
-	 * shortens the connection timeout to reduce the shutdown time in some cases.
-	 */
+	/** Immediately synchronizes the intervals with the server. */
 	public void sendIntervalsImmediately() {
-		NetworkUtils.setConnectionTimeout(3000);
+		NetworkUtils.setConnectionTimeout(2000);
 		task.run();
+		NetworkUtils.setConnectionTimeout(12000);
 	}
 
     protected static void refreshUI() {}

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalTransferManagerBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalTransferManagerBase.java
@@ -40,7 +40,7 @@ public class IntervalTransferManagerBase extends RegularCheckerBase {
 		NetworkUtils.setConnectionTimeout(2000);
 		NetworkUtils.cancelTransferAfter(2000);
 		task.run();
-		NetworkUtils.setConnectionTimeout(12000);
+		NetworkUtils.setConnectionTimeout(NetworkUtils.DEFAULT_TIMEOUT);
 	}
 
     protected static void refreshUI() {}

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalTransferManagerBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalTransferManagerBase.java
@@ -38,6 +38,7 @@ public class IntervalTransferManagerBase extends RegularCheckerBase {
 	/** Immediately synchronizes the intervals with the server. */
 	public void sendIntervalsImmediately() {
 		NetworkUtils.setConnectionTimeout(2000);
+		NetworkUtils.cancelTransferAfter(2000);
 		task.run();
 		NetworkUtils.setConnectionTimeout(12000);
 	}

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalTransferManagerBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalTransferManagerBase.java
@@ -6,6 +6,7 @@ import java.util.TimerTask;
 
 import nl.tudelft.watchdog.core.logic.interval.intervaltypes.IntervalBase;
 import nl.tudelft.watchdog.core.logic.network.JsonTransferer;
+import nl.tudelft.watchdog.core.logic.network.NetworkUtils;
 import nl.tudelft.watchdog.core.logic.network.NetworkUtils.Connection;
 import nl.tudelft.watchdog.core.logic.ui.RegularCheckerBase;
 import nl.tudelft.watchdog.core.ui.preferences.PreferencesBase;
@@ -34,8 +35,13 @@ public class IntervalTransferManagerBase extends RegularCheckerBase {
 		runSetupAndStartTimeChecker();
 	}
 
-	/** Immediately synchronizes the intervals with the server. */
+	/** 
+	 * Immediately synchronizes the intervals with the server. 
+	 * This function is only called before shutting down the IDE and it first 
+	 * shortens the connection timeout to reduce the shutdown time in some cases.
+	 */
 	public void sendIntervalsImmediately() {
+		NetworkUtils.setConnectionTimeout(3000);
 		task.run();
 	}
 

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/network/NetworkUtils.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/network/NetworkUtils.java
@@ -32,8 +32,9 @@ public class NetworkUtils {
 	/**
 	 * Connection timeout to be used by the HttpClient.
 	 * Default timeout is 12 seconds. 
-	 */
-	private static int connectionTimeout = 12*1000;
+	 */	
+	public static final int DEFAULT_TIMEOUT = 12*1000;
+	private static int connectionTimeout = DEFAULT_TIMEOUT;
 	
 	/** A handle to the current Http client */ 
 	private static CloseableHttpClient client = null;
@@ -146,14 +147,14 @@ public class NetworkUtils {
 		return Connection.NETWORK_ERROR;
 	}
 
-	private static void closeHttpClientGracefully(CloseableHttpClient client) {
-		if(client != null) {
-			try {
-				client.close();
-			} catch (IOException exception) {
-				// intentionally empty
-			}
-		}
+	private static void closeHttpClientGracefully(CloseableHttpClient client) {		
+		if (client == null) return;
+		
+		try {
+			client.close();
+		} catch (IOException exception) {
+			// intentionally empty
+		}		
 	}
 
 	/**

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/network/NetworkUtils.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/network/NetworkUtils.java
@@ -26,6 +26,12 @@ import nl.tudelft.watchdog.core.util.WatchDogLogger;
  * Utility functions for accessing the network.
  */
 public class NetworkUtils {
+	
+	/**
+	 * Connection timeout to be used by the HttpClient.
+	 * Default timeout is 12 seconds. 
+	 */
+	private static int connectionTimeout = 12*1000;
 
 	/**
 	 * An enum denoting the three possible different connection outcomes:
@@ -45,6 +51,13 @@ public class NetworkUtils {
 		 */
 		NETWORK_ERROR
 	};
+	
+	/**
+	 * Change the default value of the connection timeout to the specified one.
+	 */
+	public static void setConnectionTimeout(int timeout) {
+		connectionTimeout = timeout;
+	}
 
 	/**
 	 * Returns the content at the given URL.
@@ -156,7 +169,7 @@ public class NetworkUtils {
 			}
 		} catch (IOException e) {
 			// server unreachable case
-			errorMessage = "Failed to commuincate with our server: " + e + " "
+			errorMessage = "Failed to communicate with our server: " + e + " "
 					+ e.getMessage();
 		} catch (IllegalStateException e) {
 			// URL wrongly formatted (target host is null)
@@ -250,7 +263,6 @@ public class NetworkUtils {
 	 * Creates a vanilla HTTP client builder with some timeouts.
 	 */
 	private static HttpClientBuilder createPlainHttpClientBuilder() {
-		int connectionTimeout = 12000;
 		RequestConfig config = RequestConfig.custom()
 				.setConnectionRequestTimeout(connectionTimeout)
 				.setConnectTimeout(connectionTimeout)


### PR DESCRIPTION
This PR reduces the connection timeout from 12 to 3 seconds before shutting down the IDE. In this way, Eclipse is shut down after 3 seconds instead of 12 in case of a very slow connection. The connection timeout that is used during the remainder of the lifetime of the plugin remains 12 seconds. This PR should therefore close  #129.