### PR TITLE
Adds check to avoid losing intervals

### DIFF
--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/intervaltypes/IntervalBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/intervaltypes/IntervalBase.java
@@ -120,7 +120,15 @@ abstract public class IntervalBase extends WatchDogTransferable
 		return intervalType;
 	}
 
-	/** Necessary for storage of Intervals. */
+	/**
+	 * Necessary for storage of Intervals. The comparison is first based on the
+	 * end dates of the two intervals. If these dates are equal but the
+	 * intervals themselves not, the comparison is based on the start dates. If
+	 * the start dates are also equal, the type of the intervals is used to
+	 * produce the result of this method. This sequence of step is required to
+	 * ensure that intervals are not lost when two or more intervals have the
+	 * same end date.
+	 */
 	public int compareTo(IntervalBase comparedInterval) {
 		int res = getEnd().compareTo(comparedInterval.getEnd());
 		if (res == 0 && !this.equals(comparedInterval)) {
@@ -145,6 +153,11 @@ abstract public class IntervalBase extends WatchDogTransferable
 		return super.clone();
 	}
 
+	/**
+	 * Checks whether the parameter is an IntervalBase and is equal to this by
+	 * comparing the start dates, end dates, types and session seeds of the two
+	 * intervals.
+	 */
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/intervaltypes/IntervalBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/intervaltypes/IntervalBase.java
@@ -160,30 +160,40 @@ abstract public class IntervalBase extends WatchDogTransferable
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (obj == null) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
+		}
 		IntervalBase other = (IntervalBase) obj;
 		if (end == null) {
-			if (other.end != null)
+			if (other.end != null) {
 				return false;
-		} else if (!end.equals(other.end))
+			}
+		} else if (!end.equals(other.end)) {
 			return false;
-		if (intervalType != other.intervalType)
+		}
+		if (intervalType != other.intervalType) {
 			return false;
+		}
 		if (sessionSeed == null) {
-			if (other.sessionSeed != null)
+			if (other.sessionSeed != null) {
 				return false;
-		} else if (!sessionSeed.equals(other.sessionSeed))
+			}
+		} else if (!sessionSeed.equals(other.sessionSeed)) {
 			return false;
+		}
 		if (start == null) {
-			if (other.start != null)
+			if (other.start != null) {
 				return false;
-		} else if (!start.equals(other.start))
+			}
+		} else if (!start.equals(other.start)) {
 			return false;
+		}
 		return true;
 	}
 

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/intervaltypes/IntervalBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/intervaltypes/IntervalBase.java
@@ -12,8 +12,8 @@ import org.joda.time.format.PeriodFormat;
 import com.google.gson.annotations.SerializedName;
 
 /** The interval base. */
-abstract public class IntervalBase extends WatchDogTransferable implements
-		Serializable, Comparable<IntervalBase>, Cloneable {
+abstract public class IntervalBase extends WatchDogTransferable
+		implements Serializable, Comparable<IntervalBase>, Cloneable {
 
 	/** The version id of this class. */
 	private static final long serialVersionUID = 2L;
@@ -124,7 +124,10 @@ abstract public class IntervalBase extends WatchDogTransferable implements
 	public int compareTo(IntervalBase comparedInterval) {
 		int res = getEnd().compareTo(comparedInterval.getEnd());
 		if (res == 0 && !this.equals(comparedInterval)) {
-			res = -1;
+			res = getStart().compareTo(comparedInterval.getStart());
+			if (res == 0) {
+				res = getType().compareTo(comparedInterval.getType()) > 0 ? 1 : -1;
+			}
 		}
 		return res;
 	}
@@ -140,6 +143,35 @@ abstract public class IntervalBase extends WatchDogTransferable implements
 	@Override
 	public Object clone() throws CloneNotSupportedException {
 		return super.clone();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		IntervalBase other = (IntervalBase) obj;
+		if (end == null) {
+			if (other.end != null)
+				return false;
+		} else if (!end.equals(other.end))
+			return false;
+		if (intervalType != other.intervalType)
+			return false;
+		if (sessionSeed == null) {
+			if (other.sessionSeed != null)
+				return false;
+		} else if (!sessionSeed.equals(other.sessionSeed))
+			return false;
+		if (start == null) {
+			if (other.start != null)
+				return false;
+		} else if (!start.equals(other.start))
+			return false;
+		return true;
 	}
 
 }

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/intervaltypes/IntervalBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/intervaltypes/IntervalBase.java
@@ -122,7 +122,11 @@ abstract public class IntervalBase extends WatchDogTransferable implements
 
 	/** Necessary for storage of Intervals. */
 	public int compareTo(IntervalBase comparedInterval) {
-		return getEnd().compareTo(comparedInterval.getEnd());
+		int res = getEnd().compareTo(comparedInterval.getEnd());
+		if (res == 0 && !this.equals(comparedInterval)) {
+			res = -1;
+		}
+		return res;
 	}
 
 	/**

--- a/WatchDogEclipsePlugin/WatchDogUnitTests/src/nl/tudelft/watchdog/logic/interval/IntervalComparisonTest.java
+++ b/WatchDogEclipsePlugin/WatchDogUnitTests/src/nl/tudelft/watchdog/logic/interval/IntervalComparisonTest.java
@@ -1,0 +1,84 @@
+package nl.tudelft.watchdog.logic.interval;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Date;
+
+import org.junit.Test;
+
+import nl.tudelft.watchdog.core.logic.interval.intervaltypes.IDEOpenInterval;
+import nl.tudelft.watchdog.core.logic.interval.intervaltypes.UserActiveInterval;
+
+/**
+ * Test class for comparing intervals by testing the IntervalBase.compareTo
+ * method.
+ */
+public class IntervalComparisonTest {
+
+	@Test
+	public void testComparisonEqualIntervalsSameObject() {
+		UserActiveInterval interval = new UserActiveInterval(new Date());
+		interval.close();
+		assertEquals(0, interval.compareTo(interval));
+	}
+
+	@Test
+	public void testComparisonEqualIntervalsDifferentObjectsSameType() {
+		Date start = new Date();
+		UserActiveInterval interval1 = new UserActiveInterval(start);
+		UserActiveInterval interval2 = new UserActiveInterval(start);
+		Date end = new Date();
+		interval1.close();
+		interval1.setEndTime(end);
+		interval2.close();
+		interval2.setEndTime(end);
+		assertEquals(0, interval1.compareTo(interval2));
+	}
+
+	@Test
+	public void testComparisonEqualIntervalsDifferentObjectsDifferentType() {
+		Date start = new Date();
+		UserActiveInterval interval1 = new UserActiveInterval(start);
+		IDEOpenInterval interval2 = new IDEOpenInterval(start);
+		interval1.close();
+		interval2.close();
+		interval2.setEndTime(interval1.getEnd());
+		assertEquals(1, interval1.compareTo(interval2));
+		assertEquals(-1, interval2.compareTo(interval1));
+	}
+
+	@Test
+	public void testComparisonEqualIntervalsDifferentObjectsDifferentStart() {
+		UserActiveInterval interval1 = new UserActiveInterval(new Date(1));
+		UserActiveInterval interval2 = new UserActiveInterval(new Date(2));
+		interval1.close();
+		interval2.close();
+		interval2.setEndTime(interval1.getEnd());
+		assertEquals(-1, interval1.compareTo(interval2));
+		assertEquals(1, interval2.compareTo(interval1));
+	}
+
+	@Test
+	public void testComparisonTwoDifferentIntervalsDifferentType() {
+		UserActiveInterval interval1 = new UserActiveInterval(new Date(1));
+		IDEOpenInterval interval2 = new IDEOpenInterval(new Date(2));
+		interval1.close();
+		interval1.setEndTime(new Date(2));
+		interval2.close();
+		interval2.setEndTime(new Date(3));
+		assertEquals(-1, interval1.compareTo(interval2));
+		assertEquals(1, interval2.compareTo(interval1));
+	}
+	
+	@Test
+	public void testComparisonTwoDifferentIntervalsSameType() {
+		UserActiveInterval interval1 = new UserActiveInterval(new Date(1));
+		UserActiveInterval interval2 = new UserActiveInterval(new Date(2));
+		interval1.close();
+		interval1.setEndTime(new Date(2));
+		interval2.close();
+		interval2.setEndTime(new Date(3));
+		assertEquals(-1, interval1.compareTo(interval2));
+		assertEquals(1, interval2.compareTo(interval1));
+	}
+}


### PR DESCRIPTION
It turned out that the bug described in #230 is caused by a defect in `IntervalBase.compareTo`. The set in the `IntervalPersisterBase` is actually a `NavigableSet`. Therefore, when an item is added to this set, the `IntervalBase.compareTo` method is called to find the insert position of the new item. However, when the result of this comparison is 0, the two intervals are "equal" and therefore the second one is not added to ensure the properties of a set. 

However, the implementation of the  `IntervalBase.compareTo` method only compares the end dates of two intervals. So, when the end dates of two intervals are equal, the result of the comparison will be 0 and the second interval is not added to the set. Unfortunately, the same end date might be used for multiple different intervals, especially when WD is shut down. Therefore, I've added a check that changes the result of the comparison when the two intervals are not actually equal. In this way, all different intervals are actually added to the set, while equal intervals are still only added once.