### PR TITLE
Updates IntelliJ version from 15.0.1 to 15.0.5

### DIFF
--- a/WatchDogIntelliJPlugin/WatchDog/pom.xml
+++ b/WatchDogIntelliJPlugin/WatchDog/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.jetbrains</groupId>
 			<artifactId>org.jetbrains.intellij-ce</artifactId>
-			<version>15.0.1</version>
+			<version>15.0.5</version>
 			<type>zip</type>
 			<scope>provided</scope>
 		</dependency>

--- a/WatchDogIntelliJPlugin/fetchIdea.sh
+++ b/WatchDogIntelliJPlugin/fetchIdea.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-idea_version="15.0.1"
+idea_version="15.0.5"
 idea_zip="ideaIC-$idea_version.tar.gz"
 idea_URL="http://download.jetbrains.com/idea/$idea_zip"
 build_dir="build_cache"


### PR DESCRIPTION
After investigating the recent trend of failing builds on Travis CI, it seems like the IntelliJ version we are currently using (15.0.1) is no longer available for download. Therefore, this PR updates the version to 15.0.5 in order to let new builds pass again.