### PR TITLE
Debug survey link

### DIFF
--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/util/UIUtils.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/util/UIUtils.java
@@ -317,6 +317,7 @@ public class UIUtils {
 				+ Preferences.getInstance().getUserId()
 				+ "&entry.87074017=Java&entry.1002919343=Eclipse&entry.2010347695&entry.2084367812";
 		UIUtils.createLinkedLabel(container, new BrowserOpenerSelection(),
-				"Start the survey\n", surveyLink);
+				"Share your thoughts on debugging and win an additional Amazon voucher!\n",
+				surveyLink);
 	}
 }

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/util/UIUtils.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/util/UIUtils.java
@@ -1,12 +1,5 @@
 package nl.tudelft.watchdog.eclipse.ui.util;
 
-import nl.tudelft.watchdog.core.util.WatchDogLogger;
-import nl.tudelft.watchdog.eclipse.Activator;
-import nl.tudelft.watchdog.eclipse.ui.WatchDogView;
-import nl.tudelft.watchdog.eclipse.ui.util.CommandExecuterBase.CommandExecuter;
-import nl.tudelft.watchdog.eclipse.ui.util.CommandExecuterBase.CommandRefresher;
-import nl.tudelft.watchdog.eclipse.util.WatchDogUtils;
-
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
@@ -24,6 +17,14 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
+
+import nl.tudelft.watchdog.core.util.WatchDogLogger;
+import nl.tudelft.watchdog.eclipse.Activator;
+import nl.tudelft.watchdog.eclipse.ui.WatchDogView;
+import nl.tudelft.watchdog.eclipse.ui.preferences.Preferences;
+import nl.tudelft.watchdog.eclipse.ui.util.CommandExecuterBase.CommandExecuter;
+import nl.tudelft.watchdog.eclipse.ui.util.CommandExecuterBase.CommandRefresher;
+import nl.tudelft.watchdog.eclipse.util.WatchDogUtils;
 
 /** Utility methods for the UI. */
 public class UIUtils {
@@ -89,7 +90,8 @@ public class UIUtils {
 	/** Creates uneditable text field. */
 	public static Text createTextField(Composite parent, String content) {
 		Text text = new Text(parent, SWT.SINGLE | SWT.BORDER);
-		text.setLayoutData(new GridData(SWT.BOTTOM, SWT.BEGINNING, true, false));
+		text.setLayoutData(
+				new GridData(SWT.BOTTOM, SWT.BEGINNING, true, false));
 		text.setText(content);
 		text.setEditable(false);
 		return text;
@@ -135,7 +137,8 @@ public class UIUtils {
 	 * @return A {@link GridLayout}ed composite with the given number of
 	 *         columns.
 	 */
-	public static Composite createGridedComposite(Composite parent, int columns) {
+	public static Composite createGridedComposite(Composite parent,
+			int columns) {
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setLayout(new GridLayout(columns, false));
 		return composite;
@@ -222,7 +225,8 @@ public class UIUtils {
 					"resources/images/watchdog_icon_warning.png");
 
 	/** Creates and returns a label with the given text and color. */
-	public static Label createLabel(String text, Composite parent, Color color) {
+	public static Label createLabel(String text, Composite parent,
+			Color color) {
 		Label label = createLabel(text, parent);
 		label.setForeground(color);
 		return label;
@@ -234,14 +238,15 @@ public class UIUtils {
 	}
 
 	/** Creates a logo from the given image url. */
-	public static Label createLogo(Composite logoContainer, String imageLocation) {
+	public static Label createLogo(Composite logoContainer,
+			String imageLocation) {
 		Label watchdogLogo = new Label(logoContainer, SWT.NONE);
 		ImageDescriptor watchdogLogoImageDescriptor = Activator
 				.imageDescriptorFromPlugin(Activator.PLUGIN_ID, imageLocation);
 		Image watchdogLogoImage = watchdogLogoImageDescriptor.createImage();
 		watchdogLogo.setImage(watchdogLogoImage);
-		watchdogLogo.setLayoutData(new GridData(SWT.CENTER, SWT.BEGINNING,
-				true, false));
+		watchdogLogo.setLayoutData(
+				new GridData(SWT.CENTER, SWT.BEGINNING, true, false));
 		return watchdogLogo;
 	}
 
@@ -287,8 +292,8 @@ public class UIUtils {
 	/** Creates a Combo List of String items. */
 	public static Combo createComboList(Composite parent,
 			SelectionListener listener, String[] items, int defaultSelection) {
-		Combo comboList = new Combo(parent, SWT.DROP_DOWN | SWT.BORDER
-				| SWT.READ_ONLY);
+		Combo comboList = new Combo(parent,
+				SWT.DROP_DOWN | SWT.BORDER | SWT.READ_ONLY);
 		comboList.setItems(items);
 		comboList.select(defaultSelection);
 		comboList.addSelectionListener(listener);
@@ -301,5 +306,17 @@ public class UIUtils {
 				+ WatchDogUtils.getProjectSetting().projectId + ".html";
 		UIUtils.createLinkedLabel(container, new BrowserOpenerSelection(),
 				"Open Report.", projectReport);
+	}
+
+	/**
+	 * Creates a linked label that opens the debug survey in the browser with
+	 * the correct User ID.
+	 */
+	public static void createStartDebugSurveyLink(Composite container) {
+		String surveyLink = "https://docs.google.com/forms/d/1ybD1jC-iICXNlmQpyPEFngtmOtodicDr18E1ZbfBtx4/viewform?entry.1872114938="
+				+ Preferences.getInstance().getUserId()
+				+ "&entry.87074017=Java&entry.1002919343=Eclipse&entry.2010347695&entry.2084367812";
+		UIUtils.createLinkedLabel(container, new BrowserOpenerSelection(),
+				"Start the survey\n", surveyLink);
 	}
 }

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectCreatedEndingPage.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectCreatedEndingPage.java
@@ -1,6 +1,7 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration;
 
 import org.eclipse.jface.wizard.IWizard;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 
 import nl.tudelft.watchdog.core.logic.network.JsonTransferer;
@@ -124,12 +125,31 @@ public class ProjectCreatedEndingPage extends RegistrationEndingPageBase {
 			dynamicComposite = UIUtils.createGridedComposite(topComposite, 1);
 			dynamicComposite.setLayoutData(UIUtils.createFullGridUsageData());
 			if (wizard.userWelcomePage.getRegisterNewId()) {
+				createDebugSurveyInfo();
 				userRegistrationPage
 						.createUserRegistrationSummary(dynamicComposite);
 			}
 			createProjectRegistrationSummary();
 			return;
 		}
+	}
+
+	/**
+	 * Shows the label and link to ask the new user to fill out the survey on
+	 * debugging.
+	 */
+	private void createDebugSurveyInfo() {
+		// Resize the dialog (=>increases height).
+		Rectangle bounds = dynamicComposite.getShell().getBounds();
+		Rectangle newBounds = new Rectangle(bounds.x, bounds.y, bounds.width,
+				bounds.height + 50);
+		dynamicComposite.getShell().setBounds(newBounds);
+
+		// Create label and link.
+		UIUtils.createBoldLabel(
+				"Do you want to win an Amazon voucher and help research?\nPlease fill out this 5 minute survey on debugging: ",
+				dynamicComposite);
+		UIUtils.createStartDebugSurveyLink(dynamicComposite);
 	}
 
 	private void createProjectRegistrationSummary() {

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectCreatedEndingPage.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectCreatedEndingPage.java
@@ -1,7 +1,6 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration;
 
 import org.eclipse.jface.wizard.IWizard;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 
 import nl.tudelft.watchdog.core.logic.network.JsonTransferer;
@@ -139,15 +138,8 @@ public class ProjectCreatedEndingPage extends RegistrationEndingPageBase {
 	 * debugging.
 	 */
 	private void createDebugSurveyInfo() {
-		// Resize the dialog (=>increases height).
-		Rectangle bounds = dynamicComposite.getShell().getBounds();
-		Rectangle newBounds = new Rectangle(bounds.x, bounds.y, bounds.width,
-				bounds.height + 50);
-		dynamicComposite.getShell().setBounds(newBounds);
-
-		// Create label and link.
 		UIUtils.createBoldLabel(
-				"Do you want to win an Amazon voucher and help research?\nPlease fill out this 5 minute survey on debugging: ",
+				"Do you ever debug? Did you know WatchDog now also reports on debugging?",
 				dynamicComposite);
 		UIUtils.createStartDebugSurveyLink(dynamicComposite);
 	}

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/util/UIUtils.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/util/UIUtils.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.util.IconLoader;
 import com.intellij.ui.HyperlinkLabel;
 import com.intellij.openapi.ui.ComboBox;
 
+import nl.tudelft.watchdog.intellij.ui.preferences.Preferences;
 import nl.tudelft.watchdog.intellij.util.WatchDogUtils;
 
 import java.awt.*;
@@ -339,6 +340,16 @@ public class UIUtils {
         UIUtils.createHyperLinkLabel(parent, "Open Report.", projectReport);
     }
 
+    /**
+     * Creates a linked label that opens the debug survey in the browser with
+     * the correct User ID.
+     */
+    public static void createStartDebugSurveyLink(JComponent parent) {
+        String surveyLink = "https://docs.google.com/forms/d/1ybD1jC-iICXNlmQpyPEFngtmOtodicDr18E1ZbfBtx4/viewform?entry.1872114938="
+                + Preferences.getInstance().getUserId()
+                + "&entry.87074017=Java&entry.1002919343=IntelliJ&entry.2010347695&entry.2084367812";
+        UIUtils.createHyperLinkLabel(parent, "Start the survey", surveyLink);
+    }
 
     /**
      * Creates and returns a JPanel Group with an enclosed Grid layout with

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/util/UIUtils.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/util/UIUtils.java
@@ -348,7 +348,7 @@ public class UIUtils {
         String surveyLink = "https://docs.google.com/forms/d/1ybD1jC-iICXNlmQpyPEFngtmOtodicDr18E1ZbfBtx4/viewform?entry.1872114938="
                 + Preferences.getInstance().getUserId()
                 + "&entry.87074017=Java&entry.1002919343=IntelliJ&entry.2010347695&entry.2084367812";
-        UIUtils.createHyperLinkLabel(parent, "Start the survey", surveyLink);
+        UIUtils.createHyperLinkLabel(parent, "Share your thoughts on debugging and win an additional Amazon voucher!", surveyLink);
     }
 
     /**

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/projectregistration/ProjectCreatedEndingStep.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/projectregistration/ProjectCreatedEndingStep.java
@@ -86,10 +86,20 @@ public class ProjectCreatedEndingStep extends RegistrationEndingStepBase {
             UserProjectRegistrationWizard wizard = (UserProjectRegistrationWizard) getWizard();
             UserRegistrationStep userRegistrationStep = wizard.userRegistrationStep;
             if (wizard.userWelcomeStep.getRegisterNewId()) {
+                createDebugSurveyInfo(parent);
                 userRegistrationStep.createUserRegistrationSummary(parent);
             }
             createProjectRegistrationSummary(parent);
         }
+    }
+
+    /**
+     * Shows the label and link to ask the new user to fill out the survey on
+     * debugging.
+     */
+    private void createDebugSurveyInfo(JPanel parent) {
+        UIUtils.createBoldLabel(parent, "Do you want to win an Amazon voucher and help research? Please fill out this 5 minute survey on debugging: ");
+        UIUtils.createStartDebugSurveyLink(parent);
     }
 
     private void createProjectRegistrationSummary(JPanel parent) {

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/projectregistration/ProjectCreatedEndingStep.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/projectregistration/ProjectCreatedEndingStep.java
@@ -98,7 +98,7 @@ public class ProjectCreatedEndingStep extends RegistrationEndingStepBase {
      * debugging.
      */
     private void createDebugSurveyInfo(JPanel parent) {
-        UIUtils.createBoldLabel(parent, "Do you want to win an Amazon voucher and help research? Please fill out this 5 minute survey on debugging: ");
+        UIUtils.createBoldLabel(parent, "Do you ever debug? Did you know WatchDog now also reports on debugging?");
         UIUtils.createStartDebugSurveyLink(parent);
     }
 


### PR DESCRIPTION
Following our e-mail discussion, this PR adds a link to the survey on debugging at the end of the registration wizard as you can see below. This link refers to the cloned survey and contains the user's ID as well as two other pre-filled answers.

**Eclipse:**
![updated wizard eclipse](https://cloud.githubusercontent.com/assets/3593160/14317104/e32fac06-fc06-11e5-9d36-d93b29d52bcc.png)

**IntelliJ:**
![updated dialog intellij](https://cloud.githubusercontent.com/assets/3593160/14317324/04a1a58c-fc08-11e5-8499-649851db7ba5.png)

