### PR TITLE
Improvements to the WDView

### DIFF
--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/event/EventStatisticsBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/event/EventStatisticsBase.java
@@ -18,6 +18,12 @@ import nl.tudelft.watchdog.core.logic.storage.WatchDogItem;
  */
 public abstract class EventStatisticsBase {
 
+	/**
+	 * The amount of time before a debug interval of which the events should be
+	 * included as well.
+	 */
+	public static final int PRE_SESSION_TIME_TO_INCLUDE = 20 * 1000;
+
 	/** Persister storing all events. */
 	private final PersisterBase eventsStatisticsPersister;
 
@@ -42,10 +48,14 @@ public abstract class EventStatisticsBase {
 	/** The debug interval that is currently selected. */
 	private final DebugInterval selectedInterval;
 
+	/** The timestamp from which the events should be added. */
+	private Date startOfEventSelection;
+
 	/** Constructor. */
 	public EventStatisticsBase(DebugEventManager debugEventManager, DebugInterval selectedInterval) {
 		this.eventsStatisticsPersister = debugEventManager.getEventStatisticsPersister();
 		this.selectedInterval = selectedInterval;
+		startOfEventSelection = new Date(selectedInterval.getStart().getTime() - PRE_SESSION_TIME_TO_INCLUDE);
 		addAllEventsWithinSelectedInterval();
 	}
 
@@ -63,11 +73,11 @@ public abstract class EventStatisticsBase {
 
 	/**
 	 * @return true if and only if the event occurred within the selected debug
-	 *         interval.
+	 *         interval or in the period right before it.
 	 */
 	private boolean isWithinSelectedDebugInterval(EventBase event) {
 		Date timestamp = event.getTimestamp();
-		return selectedInterval.getStart().before(timestamp) && timestamp.before(selectedInterval.getEnd());
+		return startOfEventSelection.before(timestamp) && timestamp.before(selectedInterval.getEnd());
 	}
 
 	/**

--- a/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalStatisticsBase.java
+++ b/WatchDogCore/WatchDog/src/nl/tudelft/watchdog/core/logic/interval/IntervalStatisticsBase.java
@@ -50,6 +50,10 @@ public abstract class IntervalStatisticsBase extends IntervalManagerBase {
 	public int junitFailedRunsCount;
 	public int junitRunsCount;
 
+	public int debuggingSessionCount;
+	public Duration totalDebuggingDuration;
+	public Duration averageDebuggingDuration;
+
 	/** Pre-defined time periods for statistics display. */
 	public enum StatisticsTimePeriod {
 		MINUTES_10(10, "10 minutes."), MINUTES_30(30, "30 minutes."), HOUR_1(60, "1 hour."), HOURS_2(120,
@@ -175,6 +179,15 @@ public abstract class IntervalStatisticsBase extends IntervalManagerBase {
 		perspectiveJava = aggregateDurations(getPerspectiveIntervals(Perspective.JAVA));
 		perspectiveOther = aggregateDurations(getPerspectiveIntervals(Perspective.OTHER));
 
+		List<DebugInterval> debugIntervals = getIntervals(DebugInterval.class);
+		debuggingSessionCount = debugIntervals.size();
+		totalDebuggingDuration = aggregateDurations(debugIntervals);
+		if (debuggingSessionCount > 0) {
+			averageDebuggingDuration = totalDebuggingDuration.dividedBy(debuggingSessionCount);
+		} else {
+			averageDebuggingDuration = totalDebuggingDuration;
+		}
+
 		calculateJUnitStatistics();
 	}
 
@@ -236,8 +249,10 @@ public abstract class IntervalStatisticsBase extends IntervalManagerBase {
 	}
 
 	/**
-	 * @return the latest debug intervals in descending order of time or the empty list if none have been recorded yet. 
-	 * The maximum number of intervals that is returned can be specified using numberOfIntervals.
+	 * @return the latest debug intervals in descending order of time or the
+	 *         empty list if none have been recorded yet. The maximum number of
+	 *         intervals that is returned can be specified using
+	 *         numberOfIntervals.
 	 */
 	public List<DebugInterval> getLatestDebugIntervals(int numberOfIntervals) {
 		List<DebugInterval> latestDebugIntervals = getIntervals(DebugInterval.class);

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/logic/event/EventStatistics.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/logic/event/EventStatistics.java
@@ -86,8 +86,7 @@ public class EventStatistics extends EventStatisticsBase {
 								addDeltaTo(event.getTimestamp())));
 			}
 		} else {
-			overallTask = new Task(taskName, new Date(),
-					addDeltaTo(new Date()));
+			overallTask = new Task(taskName, new Date(0), new Date(1));
 		}
 		return overallTask;
 	}

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/WatchDogView.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/WatchDogView.java
@@ -246,7 +246,9 @@ public class WatchDogView extends ViewPart {
 		// Scale the chart based on the selected debug interval.
 		CategoryPlot plot = chart.getCategoryPlot();
 		ValueAxis axis = plot.getRangeAxis();
-		axis.setRangeWithMargins(selectedDebugInterval.getStart().getTime(),
+		axis.setRangeWithMargins(
+				selectedDebugInterval.getStart().getTime()
+						- EventStatistics.PRE_SESSION_TIME_TO_INCLUDE,
 				selectedDebugInterval.getEnd().getTime());
 
 		// Give each event type a different color.

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/WatchDogView.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/WatchDogView.java
@@ -132,7 +132,8 @@ public class WatchDogView extends ViewPart {
 			latestDebugIntervals = intervalStatistics
 					.getLatestDebugIntervals(NUMBER_OF_INTERVALS_TO_SHOW);
 			if (selectedDebugIntervalShouldBeReset()) {
-				selectedDebugInterval = latestDebugIntervals.get(0);
+				selectedDebugInterval = !latestDebugIntervals.isEmpty()
+						? latestDebugIntervals.get(0) : null;
 			}
 			createActiveView();
 		}
@@ -142,15 +143,14 @@ public class WatchDogView extends ViewPart {
 	}
 
 	/**
-	 * @return true if and only if there are debug intervals and one of the
-	 *         following two conditions hold:
+	 * @return true if and only if one of the following two conditions hold:
 	 * 
 	 *         1. No debug interval has been selected yet; or 2. A debug
 	 *         interval has been selected before, but it is no longer part of
 	 *         the latest debug intervals.
 	 */
 	private boolean selectedDebugIntervalShouldBeReset() {
-		return !latestDebugIntervals.isEmpty() && (selectedDebugInterval == null
+		return (selectedDebugInterval == null
 				|| !latestDebugIntervals.contains(selectedDebugInterval));
 	}
 

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/WatchDogView.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/WatchDogView.java
@@ -205,9 +205,9 @@ public class WatchDogView extends ViewPart {
 					.createGridedComposite(oneColumn, 2);
 			debugSectionContainer.setLayoutData(
 					new GridData(SWT.FILL, SWT.FILL, true, true));
-			createDebugStatisticsLabels(UIUtils
-					.createZeroMarginGridedComposite(debugSectionContainer, 1));
 			createSWTChart(debugSectionContainer, createDebugEventGanttChart());
+			createDebugStatisticsLabels(
+					UIUtils.createGridedComposite(debugSectionContainer, 1));
 		}
 
 		// Controls.
@@ -386,8 +386,8 @@ public class WatchDogView extends ViewPart {
 	private void createSWTChart(Composite container, JFreeChart chart) {
 		ChartComposite chartComposite = new ChartComposite(container, SWT.NONE,
 				chart, true);
-		chartComposite
-				.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		chartComposite.setLayoutData(new GridData(
+				(int) Math.floor(parent.getSize().x / 2.0) - 20, 400));
 		Rectangle bounds = chartComposite.getBounds();
 		bounds.height = bounds.width;
 		chartComposite.setBounds(bounds);

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/WatchDogView.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/WatchDogView.java
@@ -55,7 +55,8 @@ public class WatchDogView extends ViewPart {
 	private IntervalStatistics intervalStatistics;
 	private EventStatistics eventStatistics;
 
-	private Composite container;
+	private Composite generalSectionContainer;
+	private Composite testingSectionContainer;
 	private Composite debugChartContainer;
 	private Composite parent;
 
@@ -163,36 +164,40 @@ public class WatchDogView extends ViewPart {
 	}
 
 	private void createActiveView() {
-		container = UIUtils.createGridedComposite(oneColumn, 2);
-		container.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		// General section.
+		UIUtils.createTitleLabel("General", oneColumn);
+		generalSectionContainer = UIUtils.createGridedComposite(oneColumn, 2);
+		generalSectionContainer
+				.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-		createSWTChart(container, createBarChart(createDevelopmentBarDataset(),
-				"Your Development Activity", "", "minutes"));
-		createSWTChart(container, createPieChart(createDevelopmentPieDataset(),
-				"Your Development Activity"));
-		UIUtils.createLabel("", container);
-		UIUtils.createLabel("", container);
-
-		createSWTChart(container,
-				createBarChart(createProductionVSTestBarDataset(),
-						"Your Production vs. Test Activity", "", "minutes"));
-		createSWTChart(container,
-				createPieChart(createProductionVSTestPieDataset(),
-						"Your Production vs. Test Activity"));
-
-		UIUtils.createLabel("", container);
-		UIUtils.createLabel("", container);
-
-		createSWTChart(container,
+		createSWTChart(generalSectionContainer,
+				createBarChart(createDevelopmentBarDataset(),
+						"Your Development Activity", "", "minutes"));
+		createSWTChart(generalSectionContainer, createPieChart(
+				createDevelopmentPieDataset(), "Your Development Activity"));
+		createSWTChart(generalSectionContainer,
 				createPieChart(createPerspectiveViewPieDataset(),
 						"Your Perspective Activity"));
-		createSWTChart(container,
+
+		// Testing section.
+		UIUtils.createTitleLabel("Testing", oneColumn);
+		testingSectionContainer = UIUtils.createGridedComposite(oneColumn, 2);
+		testingSectionContainer
+				.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		createSWTChart(testingSectionContainer,
+				createBarChart(createProductionVSTestBarDataset(),
+						"Your Production vs. Test Activity", "", "minutes"));
+		createSWTChart(testingSectionContainer,
+				createPieChart(createProductionVSTestPieDataset(),
+						"Your Production vs. Test Activity"));
+		createSWTChart(testingSectionContainer,
 				createStackedBarChart(createJunitExecutionBarDataset(),
 						"Your Test Run Activity", "", ""));
-		UIUtils.createLabel("", container);
-		UIUtils.createLabel("", container);
 
+		// Debugging section.
 		if (selectedDebugInterval != null) {
+			UIUtils.createTitleLabel("Debugging", oneColumn);
 			createDebugIntervalSelectionList();
 			debugChartContainer = UIUtils.createGridedComposite(oneColumn, 1);
 			debugChartContainer.setLayoutData(
@@ -200,6 +205,7 @@ public class WatchDogView extends ViewPart {
 			createSWTChart(debugChartContainer, createDebugEventGanttChart());
 		}
 
+		// Controls.
 		createShowingStatisticsLine();
 		createTimeSpanSelectionList();
 	}

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/util/UIUtils.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/util/UIUtils.java
@@ -7,6 +7,7 @@ import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -76,6 +77,19 @@ public class UIUtils {
 	public static Label createLabel(String text, int style, Composite parent) {
 		Label label = new Label(parent, style);
 		label.setText(text);
+		return label;
+	}
+
+	/**
+	 * Creates and returns a bold label that can be used as a title. Also, an
+	 * extra empty label is added above the title to create vertical spacing.
+	 */
+	public static Label createTitleLabel(String text, Composite parent) {
+		createLabel("", parent);
+		Label label = createLabel(text, parent);
+		Font font = label.getFont();
+		label.setFont(
+				new Font(font.getDevice(), "WDView Title font", 16, SWT.BOLD));
 		return label;
 	}
 

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/logic/event/EventStatistics.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/logic/event/EventStatistics.java
@@ -84,8 +84,7 @@ public class EventStatistics extends EventStatisticsBase {
                                 addDeltaTo(event.getTimestamp())));
             }
         } else {
-            overallTask = new Task(taskName, new Date(),
-                    addDeltaTo(new Date()));
+            overallTask = new Task(taskName, new Date(0), new Date(1));
         }
         return overallTask;
     }

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/WatchDogView.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/WatchDogView.java
@@ -180,8 +180,8 @@ public class WatchDogView extends SimpleToolWindowPanel {
         if (selectedDebugInterval != null) {
             UIUtils.createTitleLabel(UIUtils.createGridedJPanel(oneColumn, 1), "Debugging\n");
             JComponent debugSectionContainer = UIUtils.createGridedJPanel(oneColumn, 2);
-            createDebugStatisticsLabels(UIUtils.createGridedJPanel(debugSectionContainer, 1));
             createChartPanel(debugSectionContainer, createDebugEventGanttChart());
+            createDebugStatisticsLabels(UIUtils.createGridedJPanel(debugSectionContainer, 1));
         }
 
         // Controls.

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/WatchDogView.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/WatchDogView.java
@@ -143,34 +143,45 @@ public class WatchDogView extends SimpleToolWindowPanel {
     }
 
     private void createActiveView() {
-        JComponent container = UIUtils.createGridedJPanel(oneColumn, 2);
+        // General section.
+        UIUtils.createTitleLabel(UIUtils.createGridedJPanel(oneColumn, 1), "General\n");
+
+        JComponent generalSectionContainer = UIUtils.createGridedJPanel(oneColumn, 2);
 
         createChartPanel(
-                container,
+                generalSectionContainer,
                 createBarChart(createDevelopmentBarDataset(),
                         "Your Development Activity", "", "minutes"));
         createChartPanel(
-                container,
+                generalSectionContainer,
                 createPieChart(createDevelopmentPieDataset(),
                         "Your Development Activity"));
+
+        // Testing section.
+        UIUtils.createTitleLabel(UIUtils.createGridedJPanel(oneColumn, 1), "Testing\n");
+        JComponent testingSectionContainer = UIUtils.createGridedJPanel(oneColumn, 2);
+
         createChartPanel(
-                container,
+                testingSectionContainer,
                 createBarChart(createProductionVSTestBarDataset(),
                         "Your Production vs. Test Activity", "", "minutes"));
         createChartPanel(
-                container,
+                testingSectionContainer,
                 createPieChart(createProductionVSTestPieDataset(),
                         "Your Production vs. Test Activity"));
         createChartPanel(
-                container,
+                testingSectionContainer,
                 createStackedBarChart(createJunitExecutionBarDataset(),
                         "Your Test Run Activity", "", ""));
 
+        // Debugging section.
         if (selectedDebugInterval != null) {
+            UIUtils.createTitleLabel(UIUtils.createGridedJPanel(oneColumn, 1), "Debugging\n");
             createDebugIntervalSelectionList();
             createChartPanel(UIUtils.createGridedJPanel(oneColumn, 1), createDebugEventGanttChart());
         }
 
+        // Controls.
         createShowingStatisticsLines();
         createTimeSpanSelectionList();
     }

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/WatchDogView.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/WatchDogView.java
@@ -108,7 +108,7 @@ public class WatchDogView extends SimpleToolWindowPanel {
             calculateTimes();
             latestDebugIntervals = intervalStatistics.getLatestDebugIntervals(NUMBER_OF_INTERVALS_TO_SHOW);
             if (selectedDebugIntervalShouldBeReset()) {
-                selectedDebugInterval = latestDebugIntervals.get(0);
+                selectedDebugInterval = !latestDebugIntervals.isEmpty()? latestDebugIntervals.get(0) : null;
             }
             createActiveView();
             makeScrollable();
@@ -118,15 +118,14 @@ public class WatchDogView extends SimpleToolWindowPanel {
     }
 
     /**
-     * @return true if and only if there are debug intervals and one of the
-     * following two conditions hold:
-     * <p/>
+     * @return true if and only if one of the following two conditions hold:
+     *
      * 1. No debug interval has been selected yet; or 2. A debug
      * interval has been selected before, but it is no longer part of
      * the latest debug intervals.
      */
     private boolean selectedDebugIntervalShouldBeReset() {
-        return !latestDebugIntervals.isEmpty() && (selectedDebugInterval == null
+        return (selectedDebugInterval == null
                 || !latestDebugIntervals.contains(selectedDebugInterval));
     }
 

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/WatchDogView.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/WatchDogView.java
@@ -211,7 +211,7 @@ public class WatchDogView extends SimpleToolWindowPanel {
         // Scale the chart based on the selected debug interval.
         CategoryPlot plot = chart.getCategoryPlot();
         ValueAxis axis = plot.getRangeAxis();
-        axis.setRangeWithMargins(selectedDebugInterval.getStart().getTime(),
+        axis.setRangeWithMargins(selectedDebugInterval.getStart().getTime() - EventStatistics.PRE_SESSION_TIME_TO_INCLUDE,
                 selectedDebugInterval.getEnd().getTime());
 
         // Give each event type a different color.

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/util/UIUtils.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/util/UIUtils.java
@@ -10,6 +10,7 @@ import nl.tudelft.watchdog.intellij.util.WatchDogUtils;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.awt.image.ImageObserver;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import javax.swing.*;
@@ -69,6 +70,19 @@ public class UIUtils {
     public static JLabel createLabel(JComponent parent, String text, int style) {
         JLabel label = new JLabel(text, style);
         parent.add(label);
+        return label;
+    }
+
+    /**
+     * Creates and returns a bold label that can be used as a title. Also, an
+     * extra empty label is added above and below the title to create vertical spacing.
+     */
+    public static JLabel createTitleLabel(JComponent parent, String text) {
+        createLabel(parent, "\n");
+        JLabel label = createLabel(parent, text);
+        Font font = label.getFont();
+        label.setFont(new Font(font.getName(), Font.BOLD, font.getSize() + 10));
+        createLabel(parent, "\n");
         return label;
     }
 


### PR DESCRIPTION
Fixes the issues described in #247 and #248 and adds the events that occur within 20s before the debugging session in the chart as well. The resulting WDViews:

**Eclipse:**
![new wdview eclipse](https://cloud.githubusercontent.com/assets/3593160/14708149/2d9035e0-07c9-11e6-8bf9-7a7d5025721d.png)

**IntelliJ:**
![new wdview ijtop](https://cloud.githubusercontent.com/assets/3593160/14708158/35d013e2-07c9-11e6-8d71-5717dcc9b958.png)
![new wdview ijbottom](https://cloud.githubusercontent.com/assets/3593160/14708160/38264ac6-07c9-11e6-9772-57590996a57d.png)

