### PR TITLE
Change registration process to make the survey link stand out more

### DIFF
--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/handlers/StartupUIThread.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/handlers/StartupUIThread.java
@@ -58,11 +58,11 @@ public class StartupUIThread implements Runnable {
 	private void checkWhetherToDisplayUserProjectRegistrationWizard() {
 		ProjectPreferenceSetting projectSetting = preferences
 				.getOrCreateProjectSetting(workspaceName);
-		if (!WatchDogUtils.isEmpty(preferences.getUserId())
-				|| (projectSetting.startupQuestionAsked
-						&& !projectSetting.enableWatchdog)) {
-			return;
-		}
+		// if (!WatchDogUtils.isEmpty(preferences.getUserId())
+		// || (projectSetting.startupQuestionAsked
+		// && !projectSetting.enableWatchdog)) {
+		// return;
+		// }
 
 		UserRegistrationWizardDialogHandler newUserWizardHandler = new UserRegistrationWizardDialogHandler();
 		try {

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/handlers/StartupUIThread.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/handlers/StartupUIThread.java
@@ -58,11 +58,11 @@ public class StartupUIThread implements Runnable {
 	private void checkWhetherToDisplayUserProjectRegistrationWizard() {
 		ProjectPreferenceSetting projectSetting = preferences
 				.getOrCreateProjectSetting(workspaceName);
-		// if (!WatchDogUtils.isEmpty(preferences.getUserId())
-		// || (projectSetting.startupQuestionAsked
-		// && !projectSetting.enableWatchdog)) {
-		// return;
-		// }
+		if (!WatchDogUtils.isEmpty(preferences.getUserId())
+				|| (projectSetting.startupQuestionAsked
+						&& !projectSetting.enableWatchdog)) {
+			return;
+		}
 
 		UserRegistrationWizardDialogHandler newUserWizardHandler = new UserRegistrationWizardDialogHandler();
 		try {

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/RegistrationWizardBase.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/RegistrationWizardBase.java
@@ -1,15 +1,13 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards;
 
+import org.eclipse.jface.wizard.Wizard;
+
 import nl.tudelft.watchdog.eclipse.ui.handlers.StartupHandler;
-import nl.tudelft.watchdog.eclipse.ui.preferences.Preferences;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectCreatedEndingPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectIdEnteredEndingPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectRegistrationPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectSliderPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectWelcomePage;
-import nl.tudelft.watchdog.eclipse.util.WatchDogUtils;
-
-import org.eclipse.jface.wizard.Wizard;
 
 /** Base class for User and Project registration wizards. */
 public abstract class RegistrationWizardBase extends Wizard {
@@ -40,10 +38,11 @@ public abstract class RegistrationWizardBase extends Wizard {
 
 	@Override
 	public boolean performFinish() {
-		Preferences preferences = Preferences.getInstance();
-		preferences.registerProjectId(WatchDogUtils.getWorkspaceName(),
-				projectId);
-		preferences.registerProjectUse(WatchDogUtils.getWorkspaceName(), true);
+		// Preferences preferences = Preferences.getInstance();
+		// preferences.registerProjectId(WatchDogUtils.getWorkspaceName(),
+		// projectId);
+		// preferences.registerProjectUse(WatchDogUtils.getWorkspaceName(),
+		// true);
 		StartupHandler.startWatchDog();
 		return true;
 	}

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/WelcomePageBase.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/WelcomePageBase.java
@@ -3,9 +3,6 @@ package nl.tudelft.watchdog.eclipse.ui.wizards;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import nl.tudelft.watchdog.eclipse.Activator;
-import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
-
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -23,6 +20,9 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 
+import nl.tudelft.watchdog.eclipse.Activator;
+import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
+
 /**
  * The first page of a Wizard. It asks an initial yes-or no question. Depending
  * on the answer, it dynamically display an input field or an introduction page.
@@ -35,7 +35,9 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 	/** The text to welcome the user. To be changed by subclasses. */
 	protected String welcomeText;
 
-	/** The text on the label for the user input. To be changed by subclasses. */
+	/**
+	 * The text on the label for the user input. To be changed by subclasses.
+	 */
 	protected String labelText;
 
 	/** The tooltip on the label and inputText. */
@@ -107,12 +109,9 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 				setErrorMessageAndPageComplete(null);
 				removeDynamicContent(parent);
 				dynamicContent = createWelcomeComposite(parent);
-				setTitle(title
-						+ " ("
-						+ currentPageNumber
-						+ "/"
-						+ ((RegistrationWizardBase) getWizard())
-								.getTotalPages() + ")");
+				setTitle(title + " (" + currentPageNumber + "/"
+						+ ((RegistrationWizardBase) getWizard()).getTotalPages()
+						+ ")");
 				parent.layout();
 				parent.update();
 			}
@@ -130,10 +129,10 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 			public void widgetSelected(SelectionEvent e) {
 				removeDynamicContent(parent);
 				dynamicContent = createLoginComposite(parent);
-				int total = currentRegistration.equals("User") ? ((RegistrationWizardBase) getWizard())
-						.getTotalPages()
-						: ((RegistrationWizardBase) getWizard())
-								.getTotalPages() - 2;
+				int total = currentRegistration.equals("User")
+						? ((RegistrationWizardBase) getWizard()).getTotalPages()
+						: ((RegistrationWizardBase) getWizard()).getTotalPages()
+								- 2;
 				setTitle(title + " (" + currentPageNumber + "/" + total + ")");
 				parent.layout();
 				parent.update();
@@ -236,7 +235,7 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 
 	@Override
 	public boolean canFinish() {
-		return false;
+		return true;
 	}
 
 }

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -1,13 +1,8 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards.userregistration;
 
-import nl.tudelft.watchdog.eclipse.ui.wizards.RegistrationWizardBase;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectCreatedEndingPage;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectIdEnteredEndingPage;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectRegistrationPage;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectSliderPage;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectWelcomePage;
-
 import org.eclipse.jface.wizard.IWizardPage;
+
+import nl.tudelft.watchdog.eclipse.ui.wizards.RegistrationWizardBase;
 
 /**
  * A wizard that allows to register a new user or set an existing user, and then
@@ -33,21 +28,21 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
 	public void addPages() {
 		userWelcomePage = new UserWelcomePage();
 		addPage(userWelcomePage);
-		userRegistrationPage = new UserRegistrationPage(2);
-		addPage(userRegistrationPage);
-		existingUserEndingPage = new UserIdEnteredEndingPage(2);
-		addPage(existingUserEndingPage);
-		existingProjectIdPage = new ProjectIdEnteredEndingPage(3);
-		addPage(existingProjectIdPage);
-		projectWelcomePage = new ProjectWelcomePage(2);
-		addPage(projectWelcomePage);
-		projectRegistrationPage = new ProjectRegistrationPage(3);
-		addPage(projectRegistrationPage);
-		projectSliderPage = new ProjectSliderPage(4);
-		addPage(projectSliderPage);
-		projectedCreatedPage = new ProjectCreatedEndingPage(5);
-		addPage(projectedCreatedPage);
-		this.totalPages = 5;
+		// userRegistrationPage = new UserRegistrationPage(2);
+		// addPage(userRegistrationPage);
+		// existingUserEndingPage = new UserIdEnteredEndingPage(2);
+		// addPage(existingUserEndingPage);
+		// existingProjectIdPage = new ProjectIdEnteredEndingPage(3);
+		// addPage(existingProjectIdPage);
+		// projectWelcomePage = new ProjectWelcomePage(2);
+		// addPage(projectWelcomePage);
+		// projectRegistrationPage = new ProjectRegistrationPage(3);
+		// addPage(projectRegistrationPage);
+		// projectSliderPage = new ProjectSliderPage(4);
+		// addPage(projectSliderPage);
+		// projectedCreatedPage = new ProjectCreatedEndingPage(5);
+		// addPage(projectedCreatedPage);
+		this.totalPages = 1;
 	}
 
 	@Override

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserWelcomePage.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserWelcomePage.java
@@ -1,14 +1,14 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards.userregistration;
 
-import nl.tudelft.watchdog.eclipse.ui.util.BrowserOpenerSelection;
-import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
-import nl.tudelft.watchdog.eclipse.ui.wizards.WelcomePageBase;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
+
+import nl.tudelft.watchdog.eclipse.ui.util.BrowserOpenerSelection;
+import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
+import nl.tudelft.watchdog.eclipse.ui.wizards.WelcomePageBase;
 
 /**
  * The first page of the {@link UserProjectRegistrationWizard}. It asks the
@@ -23,8 +23,9 @@ public class UserWelcomePage extends WelcomePageBase {
 	/** Constructor. */
 	UserWelcomePage() {
 		super("Welcome to WatchDog!", 1);
-		setDescription("This wizard guides you through the setup of a WatchDog.\nPlease register, if you want to get your online report.");
-		welcomeTitle = "Welcome! Registration is fun and takes just 3 minutes!";
+		setDescription(
+				"You have successfully registered your project with WatchDog.");
+		welcomeTitle = "Welcome!";
 		welcomeText = "";
 		labelText = "Your WatchDog User-ID: ";
 		inputToolTip = "The User-ID we sent you upon your first WatchDog registration.";
@@ -42,8 +43,8 @@ public class UserWelcomePage extends WelcomePageBase {
 		Composite topContainer = UIUtils.createFullGridedComposite(parent, 1);
 
 		createWatchDogDescription(topContainer);
+		createSurveyLink(topContainer);
 		createLogoRow(topContainer);
-		createQuestionComposite(topContainer);
 
 		setControl(topContainer);
 		setPageComplete(false);
@@ -62,14 +63,25 @@ public class UserWelcomePage extends WelcomePageBase {
 		return composite;
 	}
 
+	private Composite createSurveyLink(Composite parent) {
+		Composite composite = UIUtils.createFullGridedComposite(parent, 1);
+
+		UIUtils.createBoldLabel(
+				"Please help us by spending at most 5 minutes on a survey:",
+				composite);
+		UIUtils.createStartDebugSurveyLink(composite);
+
+		return composite;
+	}
+
 	@Override
 	public void setVisible(boolean visible) {
 		super.setVisible(visible);
 		if (visible) {
+			welcomeTextLabel.setText(
+					"WatchDog is a free, open-source plugin that tells how you code your software.");
 			welcomeTextLabel
-					.setText("WatchDog is a free, open-source plugin that tells how you code your software.");
-			welcomeTextLabel.setLayoutData(new GridData(
-					GridData.FILL_HORIZONTAL));
+					.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 			welcomeTextLabel.getParent().layout();
 			welcomeTextLabel.getParent().update();
 

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/WatchDogStartUp.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/WatchDogStartUp.java
@@ -127,8 +127,10 @@ public class WatchDogStartUp implements ProjectComponent {
         }
 
         UserProjectRegistrationWizard wizard = new UserProjectRegistrationWizard("User and Project Registration", project);
-        wizard.show();
-        if (wizard.getExitCode() == DialogWrapper.CANCEL_EXIT_CODE) {
+        makeSilentRegistration();
+        if (userExists() && projectExists()) {
+            wizard.show();
+        } else {
             if (Messages.YES == Messages.showYesNoDialog(WATCHDOG_UNREGISTERED_WARNING, "WatchDog is not registered!", Messages.getQuestionIcon())) {
                 makeSilentRegistration();
             } else {
@@ -136,6 +138,18 @@ public class WatchDogStartUp implements ProjectComponent {
                 preferences.registerProjectUse(project.getName(), false);
             }
         }
+    }
+
+    private boolean userExists() {
+        Preferences preferences = Preferences.getInstance();
+        return preferences.getUserId() != null
+                && !preferences.getUserId().isEmpty();
+    }
+
+    private boolean projectExists() {
+        ProjectPreferenceSetting setting = WatchDogGlobals.getPreferences()
+                .getOrCreateProjectSetting(project.getName());
+        return !WatchDogUtils.isEmpty(setting.projectId);
     }
 
     private void makeSilentRegistration() {

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/WelcomeStepBase.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/WelcomeStepBase.java
@@ -197,7 +197,7 @@ public abstract class WelcomeStepBase extends WizardStep {
 
     @Override
     public boolean canFinish() {
-        return false;
+        return true;
     }
 
 }

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -44,72 +44,72 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
     public void addSteps() {
 		userWelcomeStep = new UserWelcomeStep(0, this);
 		addStep(userWelcomeStep);
-		userRegistrationStep = new UserRegistrationStep(1, this);
-		addStep(userRegistrationStep);
-		existingUserEndingStep = new UserIdEnteredEndingStep(2, this);
-		addStep(existingUserEndingStep);
-		existingProjectIdStep = new ProjectIdEnteredEndingStep(3, this);
-		addStep(existingProjectIdStep);
-		projectWelcomeStep = new ProjectWelcomeStep(4, this);
-		addStep(projectWelcomeStep);
-		projectRegistrationStep = new ProjectRegistrationStep(5, this);
-		addStep(projectRegistrationStep);
-		projectSliderStep = new ProjectSliderStep(6, this);
-		addStep(projectSliderStep);
-		projectedCreatedStep = new ProjectCreatedEndingStep(7, this);
-		addStep(projectedCreatedStep);
-		this.totalSteps = 5;
+//		userRegistrationStep = new UserRegistrationStep(1, this);
+//		addStep(userRegistrationStep);
+//		existingUserEndingStep = new UserIdEnteredEndingStep(2, this);
+//		addStep(existingUserEndingStep);
+//		existingProjectIdStep = new ProjectIdEnteredEndingStep(3, this);
+//		addStep(existingProjectIdStep);
+//		projectWelcomeStep = new ProjectWelcomeStep(4, this);
+//		addStep(projectWelcomeStep);
+//		projectRegistrationStep = new ProjectRegistrationStep(5, this);
+//		addStep(projectRegistrationStep);
+//		projectSliderStep = new ProjectSliderStep(6, this);
+//		addStep(projectSliderStep);
+//		projectedCreatedStep = new ProjectCreatedEndingStep(7, this);
+//		addStep(projectedCreatedStep);
+		this.totalSteps = 1;
 	}
 
     @Override
 	public int getNextStep(int step) {
         if(this.getCurrentStepObject().canFinish()) return getCurrentStep();
-		if (myCurrentStep == userWelcomeStep.getStepId()
-				&& !userWelcomeStep.getRegisterNewId()) {
-			return existingUserEndingStep.getStepId();
-		}
-		if (myCurrentStep == existingUserEndingStep.getStepId()) {
-			return projectWelcomeStep.getStepId();
-		}
-		if (myCurrentStep == userRegistrationStep.getStepId()) {
-			return projectRegistrationStep.getStepId();
-		}
-		if (myCurrentStep == projectWelcomeStep.getStepId()
-				&& !projectWelcomeStep.getRegisterNewId()) {
-			return existingProjectIdStep.getStepId();
-		}
-		if (myCurrentStep == projectRegistrationStep.getStepId()
-				&& projectRegistrationStep.shouldSkipProjectSliderStep()) {
-			return projectedCreatedStep.getStepId();
-		}
-		if (myCurrentStep == projectSliderStep.getStepId()) {
-			return projectedCreatedStep.getStepId();
-		}
+//		if (myCurrentStep == userWelcomeStep.getStepId()
+//				&& !userWelcomeStep.getRegisterNewId()) {
+//			return existingUserEndingStep.getStepId();
+//		}
+//		if (myCurrentStep == existingUserEndingStep.getStepId()) {
+//			return projectWelcomeStep.getStepId();
+//		}
+//		if (myCurrentStep == userRegistrationStep.getStepId()) {
+//			return projectRegistrationStep.getStepId();
+//		}
+//		if (myCurrentStep == projectWelcomeStep.getStepId()
+//				&& !projectWelcomeStep.getRegisterNewId()) {
+//			return existingProjectIdStep.getStepId();
+//		}
+//		if (myCurrentStep == projectRegistrationStep.getStepId()
+//				&& projectRegistrationStep.shouldSkipProjectSliderStep()) {
+//			return projectedCreatedStep.getStepId();
+//		}
+//		if (myCurrentStep == projectSliderStep.getStepId()) {
+//			return projectedCreatedStep.getStepId();
+//		}
 		return super.getNextStep(step);
 	}
 
     @Override
 	public int getPreviousStep(int step) {
         if(this.getCurrentStepObject().canFinish()) return -1;
-		if (myCurrentStep == existingUserEndingStep.getStepId()
-				&& !userWelcomeStep.getRegisterNewId()) {
-			return userWelcomeStep.getStepId();
-		}
-		if (myCurrentStep == projectWelcomeStep.getStepId()) {
-			return existingUserEndingStep.getStepId();
-		}
-		if (myCurrentStep == existingProjectIdStep.getStepId()
-				&& !projectWelcomeStep.getRegisterNewId()) {
-			return projectWelcomeStep.getStepId();
-		}
-		if (myCurrentStep == projectRegistrationStep.getStepId()) {
-			// Disable going back if a new user id is being created.
-			return userWelcomeStep.getRegisterNewId() ? -1
-					: projectWelcomeStep.getStepId();
-		}
-        if(myCurrentStep == projectedCreatedStep.getStepId() && projectRegistrationStep.shouldSkipProjectSliderStep()) {
-            return projectRegistrationStep.getStepId();
-        }
+//		if (myCurrentStep == existingUserEndingStep.getStepId()
+//				&& !userWelcomeStep.getRegisterNewId()) {
+//			return userWelcomeStep.getStepId();
+//		}
+//		if (myCurrentStep == projectWelcomeStep.getStepId()) {
+//			return existingUserEndingStep.getStepId();
+//		}
+//		if (myCurrentStep == existingProjectIdStep.getStepId()
+//				&& !projectWelcomeStep.getRegisterNewId()) {
+//			return projectWelcomeStep.getStepId();
+//		}
+//		if (myCurrentStep == projectRegistrationStep.getStepId()) {
+//			// Disable going back if a new user id is being created.
+//			return userWelcomeStep.getRegisterNewId() ? -1
+//					: projectWelcomeStep.getStepId();
+//		}
+//        if(myCurrentStep == projectedCreatedStep.getStepId() && projectRegistrationStep.shouldSkipProjectSliderStep()) {
+//            return projectRegistrationStep.getStepId();
+//        }
 		return super.getPreviousStep(step);
 	}
 

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserWelcomeStep.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserWelcomeStep.java
@@ -18,8 +18,8 @@ public class UserWelcomeStep extends WelcomeStepBase {
     public UserWelcomeStep(int stepNumber, RegistrationWizardBase wizard) {
 		super("Welcome to WatchDog!", stepNumber, wizard);
         myIcon = IconLoader.getIcon("/images/user.png");
-		descriptionText = "<html>This wizard guides you through the setup of WatchDog Plugin.<br>Please register, so you can access your personal online report.";
-		welcomeDisplay = "Welcome! Registration is fun and takes just 3 minutes!";
+		descriptionText = "You have successfully registered your project with WatchDog.";
+		welcomeDisplay = "Welcome!";
 		welcomeText = "WatchDog is a free, open-source plugin that tells how you code your software.";
 		labelText = "Your WatchDog User-ID: ";
 		inputToolTip = "The User-ID we sent you upon your first WatchDog registration.";
@@ -53,8 +53,15 @@ public class UserWelcomeStep extends WelcomeStepBase {
         JPanel oneColumn = UIUtils.createVerticalBoxJPanel(topPanel);
         createHeader(oneColumn);
         createWatchDogDescription(oneColumn);
+        createSurveyLink(oneColumn);
         createLogoRow(oneColumn);
-        createQuestionJPanel(oneColumn);
-        setComplete(false);
+        setComplete(true);
+    }
+
+    private void createSurveyLink(JPanel parent) {
+        JPanel panel = UIUtils.createGridedJPanel(parent, 1);
+        UIUtils.createBoldLabel(panel, "Please help us by spending at most 5 minutes on a survey:");
+        UIUtils.createStartDebugSurveyLink(panel);
+        UIUtils.createLabel(panel, "");
     }
 }


### PR DESCRIPTION
This should close #257 
The wizards (after a successful anonymous registration) now look as follows:

**IntelliJ:**
![new wizard ij](https://cloud.githubusercontent.com/assets/3593160/15176979/00299970-176e-11e6-917c-4f898236c0f0.png)

**Eclipse:**
![new wizard eclipse](https://cloud.githubusercontent.com/assets/3593160/15177002/2179154c-176e-11e6-9b84-3381eb3c76a9.png)

I've left the dead code in the code base, as I think that might be easier once we want to revert the changes later on.

