### PR TITLE
Change registration process to make the survey link stand out more

### DIFF
--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/handlers/StartupUIThread.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/handlers/StartupUIThread.java
@@ -58,11 +58,11 @@ public class StartupUIThread implements Runnable {
 	private void checkWhetherToDisplayUserProjectRegistrationWizard() {
 		ProjectPreferenceSetting projectSetting = preferences
 				.getOrCreateProjectSetting(workspaceName);
-		if (!WatchDogUtils.isEmpty(preferences.getUserId())
-				|| (projectSetting.startupQuestionAsked
-						&& !projectSetting.enableWatchdog)) {
-			return;
-		}
+		// if (!WatchDogUtils.isEmpty(preferences.getUserId())
+		// || (projectSetting.startupQuestionAsked
+		// && !projectSetting.enableWatchdog)) {
+		// return;
+		// }
 
 		UserRegistrationWizardDialogHandler newUserWizardHandler = new UserRegistrationWizardDialogHandler();
 		try {

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/handlers/StartupUIThread.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/handlers/StartupUIThread.java
@@ -58,11 +58,11 @@ public class StartupUIThread implements Runnable {
 	private void checkWhetherToDisplayUserProjectRegistrationWizard() {
 		ProjectPreferenceSetting projectSetting = preferences
 				.getOrCreateProjectSetting(workspaceName);
-		// if (!WatchDogUtils.isEmpty(preferences.getUserId())
-		// || (projectSetting.startupQuestionAsked
-		// && !projectSetting.enableWatchdog)) {
-		// return;
-		// }
+		if (!WatchDogUtils.isEmpty(preferences.getUserId())
+				|| (projectSetting.startupQuestionAsked
+						&& !projectSetting.enableWatchdog)) {
+			return;
+		}
 
 		UserRegistrationWizardDialogHandler newUserWizardHandler = new UserRegistrationWizardDialogHandler();
 		try {

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/FinishableWizardPage.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/FinishableWizardPage.java
@@ -1,8 +1,5 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards;
 
-import nl.tudelft.watchdog.core.ui.wizards.YesNoDontKnowChoice;
-import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
-
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
@@ -11,6 +8,9 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+
+import nl.tudelft.watchdog.core.ui.wizards.YesNoDontKnowChoice;
+import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
 
 /**
  * A {@link WizardPage} that can determine for itself via the
@@ -143,7 +143,9 @@ public abstract class FinishableWizardPage extends WizardPage {
 	/** Creates message on failure. */
 	public static void createFailureMessage(Composite parent, String title,
 			String message) {
-		UIUtils.createBoldLabel(title, parent);
+		if (title != null && !title.isEmpty()) {
+			UIUtils.createBoldLabel(title, parent);
+		}
 		Composite innerParent = UIUtils.createZeroMarginGridedComposite(parent,
 				2);
 		UIUtils.createLogo(innerParent, "resources/images/errormark.png");
@@ -153,13 +155,18 @@ public abstract class FinishableWizardPage extends WizardPage {
 	/** Creates message on success. */
 	public static void createSuccessMessage(Composite parent, String title,
 			String message, String id) {
-		UIUtils.createBoldLabel(title, parent);
+		if (title != null && !title.isEmpty()) {
+			UIUtils.createBoldLabel(title, parent);
+		}
 		Composite innerParent = UIUtils.createZeroMarginGridedComposite(parent,
 				2);
 		UIUtils.createLogo(innerParent, "resources/images/checkmark.png");
-		Composite displayInformation = UIUtils.createZeroMarginGridedComposite(
-				innerParent, 2);
+		Composite displayInformation = UIUtils
+				.createZeroMarginGridedComposite(innerParent, 2);
 		UIUtils.createLabel(message, displayInformation);
-		UIUtils.createTextField(displayInformation, id);
+
+		if (id != null) {
+			UIUtils.createTextField(displayInformation, id);
+		}
 	}
 }

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/RegistrationWizardBase.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/RegistrationWizardBase.java
@@ -1,15 +1,13 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards;
 
+import org.eclipse.jface.wizard.Wizard;
+
 import nl.tudelft.watchdog.eclipse.ui.handlers.StartupHandler;
-import nl.tudelft.watchdog.eclipse.ui.preferences.Preferences;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectCreatedEndingPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectIdEnteredEndingPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectRegistrationPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectSliderPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectWelcomePage;
-import nl.tudelft.watchdog.eclipse.util.WatchDogUtils;
-
-import org.eclipse.jface.wizard.Wizard;
 
 /** Base class for User and Project registration wizards. */
 public abstract class RegistrationWizardBase extends Wizard {
@@ -40,10 +38,11 @@ public abstract class RegistrationWizardBase extends Wizard {
 
 	@Override
 	public boolean performFinish() {
-		Preferences preferences = Preferences.getInstance();
-		preferences.registerProjectId(WatchDogUtils.getWorkspaceName(),
-				projectId);
-		preferences.registerProjectUse(WatchDogUtils.getWorkspaceName(), true);
+		// Preferences preferences = Preferences.getInstance();
+		// preferences.registerProjectId(WatchDogUtils.getWorkspaceName(),
+		// projectId);
+		// preferences.registerProjectUse(WatchDogUtils.getWorkspaceName(),
+		// true);
 		StartupHandler.startWatchDog();
 		return true;
 	}

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/RegistrationWizardBase.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/RegistrationWizardBase.java
@@ -34,7 +34,7 @@ public abstract class RegistrationWizardBase extends Wizard {
 	protected ProjectSliderPage projectSliderPage;
 
 	/** Project registration completed. */
-	protected ProjectCreatedEndingPage projectedCreatedPage;
+	protected ProjectCreatedEndingPage projectCreatedPage;
 
 	@Override
 	public boolean performFinish() {

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/RegistrationWizardBase.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/RegistrationWizardBase.java
@@ -38,11 +38,6 @@ public abstract class RegistrationWizardBase extends Wizard {
 
 	@Override
 	public boolean performFinish() {
-		// Preferences preferences = Preferences.getInstance();
-		// preferences.registerProjectId(WatchDogUtils.getWorkspaceName(),
-		// projectId);
-		// preferences.registerProjectUse(WatchDogUtils.getWorkspaceName(),
-		// true);
 		StartupHandler.startWatchDog();
 		return true;
 	}

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/WelcomePageBase.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/WelcomePageBase.java
@@ -3,9 +3,6 @@ package nl.tudelft.watchdog.eclipse.ui.wizards;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import nl.tudelft.watchdog.eclipse.Activator;
-import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
-
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -23,6 +20,9 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 
+import nl.tudelft.watchdog.eclipse.Activator;
+import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
+
 /**
  * The first page of a Wizard. It asks an initial yes-or no question. Depending
  * on the answer, it dynamically display an input field or an introduction page.
@@ -35,7 +35,9 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 	/** The text to welcome the user. To be changed by subclasses. */
 	protected String welcomeText;
 
-	/** The text on the label for the user input. To be changed by subclasses. */
+	/**
+	 * The text on the label for the user input. To be changed by subclasses.
+	 */
 	protected String labelText;
 
 	/** The tooltip on the label and inputText. */
@@ -107,12 +109,9 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 				setErrorMessageAndPageComplete(null);
 				removeDynamicContent(parent);
 				dynamicContent = createWelcomeComposite(parent);
-				setTitle(title
-						+ " ("
-						+ currentPageNumber
-						+ "/"
-						+ ((RegistrationWizardBase) getWizard())
-								.getTotalPages() + ")");
+				setTitle(title + " (" + currentPageNumber + "/"
+						+ ((RegistrationWizardBase) getWizard()).getTotalPages()
+						+ ")");
 				parent.layout();
 				parent.update();
 			}
@@ -130,10 +129,10 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 			public void widgetSelected(SelectionEvent e) {
 				removeDynamicContent(parent);
 				dynamicContent = createLoginComposite(parent);
-				int total = currentRegistration.equals("User") ? ((RegistrationWizardBase) getWizard())
-						.getTotalPages()
-						: ((RegistrationWizardBase) getWizard())
-								.getTotalPages() - 2;
+				int total = currentRegistration.equals("User")
+						? ((RegistrationWizardBase) getWizard()).getTotalPages()
+						: ((RegistrationWizardBase) getWizard()).getTotalPages()
+								- 2;
 				setTitle(title + " (" + currentPageNumber + "/" + total + ")");
 				parent.layout();
 				parent.update();
@@ -236,7 +235,7 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 
 	@Override
 	public boolean canFinish() {
-		return false;
+		return true;
 	}
 
 }

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/WelcomePageBase.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/WelcomePageBase.java
@@ -235,7 +235,7 @@ public abstract class WelcomePageBase extends FinishableWizardPage {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return false;
 	}
 
 }

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectCreatedEndingPage.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectCreatedEndingPage.java
@@ -63,7 +63,6 @@ public class ProjectCreatedEndingPage extends RegistrationEndingPageBase {
 		if (successfulRegistration) {
 			UIUtils.createLabel(concludingMessage, dynamicComposite);
 		}
-		return;
 	}
 
 	/**

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectCreatedEndingPage.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectCreatedEndingPage.java
@@ -1,21 +1,12 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration;
 
-import org.apache.commons.lang.WordUtils;
-import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.swt.widgets.Composite;
 
-import nl.tudelft.watchdog.core.logic.network.JsonTransferer;
-import nl.tudelft.watchdog.core.logic.network.ServerCommunicationException;
-import nl.tudelft.watchdog.core.ui.wizards.Project;
 import nl.tudelft.watchdog.core.util.WatchDogGlobals;
-import nl.tudelft.watchdog.core.util.WatchDogLogger;
-import nl.tudelft.watchdog.eclipse.ui.preferences.Preferences;
+import nl.tudelft.watchdog.eclipse.ui.handlers.StartupUIThread;
 import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
 import nl.tudelft.watchdog.eclipse.ui.wizards.FinishableWizardPage;
 import nl.tudelft.watchdog.eclipse.ui.wizards.RegistrationEndingPageBase;
-import nl.tudelft.watchdog.eclipse.ui.wizards.RegistrationWizardBase;
-import nl.tudelft.watchdog.eclipse.ui.wizards.userregistration.UserProjectRegistrationWizard;
-import nl.tudelft.watchdog.eclipse.ui.wizards.userregistration.UserRegistrationPage;
 
 /**
  * Possible finishing page in the wizard. If the project exists on the server,
@@ -33,71 +24,20 @@ public class ProjectCreatedEndingPage extends RegistrationEndingPageBase {
 	/** Constructor. */
 	public ProjectCreatedEndingPage(int pageNumber) {
 		super("Project-ID created.", pageNumber);
-		concludingMessage = "You can change these and other WatchDog settings in the Eclipse preferences."
-				+ ProjectIdEnteredEndingPage.ENCOURAGING_END_MESSAGE;
+		concludingMessage = ProjectIdEnteredEndingPage.ENCOURAGING_END_MESSAGE;
 	}
 
 	@Override
 	protected void makeRegistration() {
-		Project project = new Project(Preferences.getInstance().getUserId());
-
-		ProjectSliderPage sliderPage;
-		ProjectRegistrationPage projectPage = null;
-		if (getPreviousPage() instanceof ProjectRegistrationPage) {
-			projectPage = (ProjectRegistrationPage) getPreviousPage();
-		} else if (getPreviousPage() instanceof ProjectSliderPage) {
-			sliderPage = (ProjectSliderPage) getPreviousPage();
-			projectPage = (ProjectRegistrationPage) getPreviousPage()
-					.getPreviousPage();
-
-			project.productionPercentage = sliderPage.percentageProductionSlider
-					.getSelection();
-			project.useJunitOnlyForUnitTesting = sliderPage
-					.usesJunitForUnitTestingOnly();
-			project.followTestDrivenDesign = sliderPage.usesTestDrivenDesing();
-		}
-
-		if (projectPage == null) {
-			messageTitle = "How did you get here?";
-			messageBody = "We couldn't figure out which wizard page\n";
-			messageBody += "you came from. Please restart the registration.";
-			WatchDogLogger.getInstance().logSevere("Unknown previous page");
-			return;
-		}
-
-		// initialize from projectPage
-		project.belongToASingleSoftware = !projectPage.noSingleProjectButton
-				.getSelection();
-		project.name = projectPage.projectNameInput.getText();
-		project.website = projectPage.projectWebsite.getText();
-		project.usesContinuousIntegration = projectPage
-				.usesContinuousIntegration();
-		project.usesJunit = projectPage.usesJunit();
-		project.usesOtherTestingFrameworks = projectPage
-				.usesOtherTestingFrameworks();
-		project.usesOtherTestingForms = projectPage.usesOtherTestingForms();
-
 		windowTitle = "Registration Summary";
-
-		try {
-			id = new JsonTransferer().registerNewProject(project);
-		} catch (ServerCommunicationException exception) {
+		messageTitle = "";
+		if (StartupUIThread.makeSilentRegistration()) {
+			successfulRegistration = true;
+			messageBody = "New user and project successfully registered!";
+		} else {
 			successfulRegistration = false;
-			messageTitle = "Problem creating new project!";
-			messageBody = WordUtils.wrap(exception.getMessage(), 100, null,
-					true);
-			messageBody += "\nAre you connected to the internet, and is port 80 open?";
-			messageBody += "\nPlease contact us via www.testroots.org. \nWe'll troubleshoot the issue!";
-			WatchDogLogger.getInstance().logSevere(exception);
-			return;
+			messageBody = "Registration failed! Do you have an internet connection?";
 		}
-
-		successfulRegistration = true;
-
-		((RegistrationWizardBase) getWizard()).setProjectId(id);
-
-		messageTitle = "New project registered!";
-		messageBody = "Your new project id is registered: ";
 	}
 
 	@Override
@@ -116,24 +56,14 @@ public class ProjectCreatedEndingPage extends RegistrationEndingPageBase {
 
 	private void createPageContent() {
 		setTitle(windowTitle);
-		if (isThisProjectWizard()) {
-			dynamicComposite = UIUtils.createGridedComposite(topComposite, 1);
-			dynamicComposite.setLayoutData(UIUtils.createFullGridUsageData());
-			createProjectRegistrationSummary();
-			return;
-		} else {
-			UserProjectRegistrationWizard wizard = (UserProjectRegistrationWizard) getWizard();
-			UserRegistrationPage userRegistrationPage = wizard.userRegistrationPage;
-			dynamicComposite = UIUtils.createGridedComposite(topComposite, 1);
-			dynamicComposite.setLayoutData(UIUtils.createFullGridUsageData());
-			if (wizard.userWelcomePage.getRegisterNewId()) {
-				createDebugSurveyInfo();
-				userRegistrationPage
-						.createUserRegistrationSummary(dynamicComposite);
-			}
-			createProjectRegistrationSummary();
-			return;
+		dynamicComposite = UIUtils.createGridedComposite(topComposite, 1);
+		dynamicComposite.setLayoutData(UIUtils.createFullGridUsageData());
+		createUserAndProjectRegistrationSummary();
+		createDebugSurveyInfo();
+		if (successfulRegistration) {
+			UIUtils.createLabel(concludingMessage, dynamicComposite);
 		}
+		return;
 	}
 
 	/**
@@ -146,21 +76,15 @@ public class ProjectCreatedEndingPage extends RegistrationEndingPageBase {
 		UIUtils.createStartDebugSurveyLink(dynamicComposite);
 	}
 
-	private void createProjectRegistrationSummary() {
+	private void createUserAndProjectRegistrationSummary() {
 		if (successfulRegistration) {
 			FinishableWizardPage.createSuccessMessage(dynamicComposite,
-					messageTitle, messageBody, id);
-			UIUtils.createLabel(concludingMessage, dynamicComposite);
+					messageTitle, messageBody, null);
 		} else {
 			FinishableWizardPage.createFailureMessage(dynamicComposite,
 					messageTitle, messageBody);
 			setPageComplete(false);
 		}
-	}
-
-	private boolean isThisProjectWizard() {
-		IWizard wizard = getWizard();
-		return wizard instanceof ProjectRegistrationWizard;
 	}
 
 	@Override

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectRegistrationWizard.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/projectregistration/ProjectRegistrationWizard.java
@@ -17,8 +17,8 @@ public class ProjectRegistrationWizard extends RegistrationWizardBase {
 		addPage(projectSliderPage);
 		existingProjectIdPage = new ProjectIdEnteredEndingPage(2);
 		addPage(existingProjectIdPage);
-		projectedCreatedPage = new ProjectCreatedEndingPage(4);
-		addPage(projectedCreatedPage);
+		projectCreatedPage = new ProjectCreatedEndingPage(4);
+		addPage(projectCreatedPage);
 		this.totalPages = 4;
 	}
 
@@ -34,10 +34,10 @@ public class ProjectRegistrationWizard extends RegistrationWizardBase {
 		}
 		if (currentPage == projectRegistrationPage
 				&& projectRegistrationPage.shouldSkipProjectSliderPage()) {
-			return projectedCreatedPage;
+			return projectCreatedPage;
 		}
 		if (currentPage == projectSliderPage) {
-			return projectedCreatedPage;
+			return projectCreatedPage;
 		}
 		return super.getNextPage(page);
 	}

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -29,18 +29,6 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
 	public void addPages() {
 		userWelcomePage = new UserWelcomePage();
 		addPage(userWelcomePage);
-		// userRegistrationPage = new UserRegistrationPage(2);
-		// addPage(userRegistrationPage);
-		// existingUserEndingPage = new UserIdEnteredEndingPage(2);
-		// addPage(existingUserEndingPage);
-		// existingProjectIdPage = new ProjectIdEnteredEndingPage(3);
-		// addPage(existingProjectIdPage);
-		// projectWelcomePage = new ProjectWelcomePage(2);
-		// addPage(projectWelcomePage);
-		// projectRegistrationPage = new ProjectRegistrationPage(3);
-		// addPage(projectRegistrationPage);
-		// projectSliderPage = new ProjectSliderPage(4);
-		// addPage(projectSliderPage);
 		projectCreatedPage = new ProjectCreatedEndingPage(2);
 		addPage(projectCreatedPage);
 		this.totalPages = 2;

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -3,6 +3,7 @@ package nl.tudelft.watchdog.eclipse.ui.wizards.userregistration;
 import org.eclipse.jface.wizard.IWizardPage;
 
 import nl.tudelft.watchdog.eclipse.ui.wizards.RegistrationWizardBase;
+import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectCreatedEndingPage;
 
 /**
  * A wizard that allows to register a new user or set an existing user, and then
@@ -40,37 +41,16 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
 		// addPage(projectRegistrationPage);
 		// projectSliderPage = new ProjectSliderPage(4);
 		// addPage(projectSliderPage);
-		// projectedCreatedPage = new ProjectCreatedEndingPage(5);
-		// addPage(projectedCreatedPage);
-		this.totalPages = 1;
+		projectCreatedPage = new ProjectCreatedEndingPage(2);
+		addPage(projectCreatedPage);
+		this.totalPages = 2;
 	}
 
 	@Override
 	public IWizardPage getNextPage(IWizardPage page) {
 		IWizardPage currentPage = getContainer().getCurrentPage();
-		if (currentPage == userWelcomePage
-				&& !userWelcomePage.getRegisterNewId()) {
-			return existingUserEndingPage;
-		}
-		if (currentPage == existingUserEndingPage) {
-			return projectWelcomePage;
-		}
-		if (currentPage == userRegistrationPage) {
-			return projectRegistrationPage;
-		}
-		if (currentPage == projectWelcomePage
-				&& !projectWelcomePage.getRegisterNewId()) {
-			return existingProjectIdPage;
-		}
-		if (currentPage == existingProjectIdPage) {
-			return null;
-		}
-		if (currentPage == projectRegistrationPage
-				&& projectRegistrationPage.shouldSkipProjectSliderPage()) {
-			return projectedCreatedPage;
-		}
-		if (currentPage == projectSliderPage) {
-			return projectedCreatedPage;
+		if (currentPage == userWelcomePage) {
+			return projectCreatedPage;
 		}
 		return super.getNextPage(page);
 	}
@@ -78,21 +58,9 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
 	@Override
 	public IWizardPage getPreviousPage(IWizardPage page) {
 		IWizardPage currentPage = getContainer().getCurrentPage();
-		if (currentPage == existingUserEndingPage
-				&& !userWelcomePage.getRegisterNewId()) {
-			return userWelcomePage;
-		}
-		if (currentPage == projectWelcomePage) {
-			return existingUserEndingPage;
-		}
-		if (currentPage == existingProjectIdPage
-				&& !projectWelcomePage.getRegisterNewId()) {
-			return projectWelcomePage;
-		}
-		if (currentPage == projectRegistrationPage) {
-			// Disable going back if a new user id is being created.
-			return userWelcomePage.getRegisterNewId() ? null
-					: projectWelcomePage;
+		if (currentPage == projectCreatedPage) {
+			// Disable going back.
+			return null;
 		}
 		return super.getPreviousPage(page);
 	}

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -1,13 +1,8 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards.userregistration;
 
-import nl.tudelft.watchdog.eclipse.ui.wizards.RegistrationWizardBase;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectCreatedEndingPage;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectIdEnteredEndingPage;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectRegistrationPage;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectSliderPage;
-import nl.tudelft.watchdog.eclipse.ui.wizards.projectregistration.ProjectWelcomePage;
-
 import org.eclipse.jface.wizard.IWizardPage;
+
+import nl.tudelft.watchdog.eclipse.ui.wizards.RegistrationWizardBase;
 
 /**
  * A wizard that allows to register a new user or set an existing user, and then
@@ -33,21 +28,21 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
 	public void addPages() {
 		userWelcomePage = new UserWelcomePage();
 		addPage(userWelcomePage);
-		userRegistrationPage = new UserRegistrationPage(2);
-		addPage(userRegistrationPage);
-		existingUserEndingPage = new UserIdEnteredEndingPage(2);
-		addPage(existingUserEndingPage);
-		existingProjectIdPage = new ProjectIdEnteredEndingPage(3);
-		addPage(existingProjectIdPage);
-		projectWelcomePage = new ProjectWelcomePage(2);
-		addPage(projectWelcomePage);
-		projectRegistrationPage = new ProjectRegistrationPage(3);
-		addPage(projectRegistrationPage);
-		projectSliderPage = new ProjectSliderPage(4);
-		addPage(projectSliderPage);
-		projectedCreatedPage = new ProjectCreatedEndingPage(5);
-		addPage(projectedCreatedPage);
-		this.totalPages = 5;
+		// userRegistrationPage = new UserRegistrationPage(2);
+		// addPage(userRegistrationPage);
+		// existingUserEndingPage = new UserIdEnteredEndingPage(2);
+		// addPage(existingUserEndingPage);
+		// existingProjectIdPage = new ProjectIdEnteredEndingPage(3);
+		// addPage(existingProjectIdPage);
+		// projectWelcomePage = new ProjectWelcomePage(2);
+		// addPage(projectWelcomePage);
+		// projectRegistrationPage = new ProjectRegistrationPage(3);
+		// addPage(projectRegistrationPage);
+		// projectSliderPage = new ProjectSliderPage(4);
+		// addPage(projectSliderPage);
+		// projectedCreatedPage = new ProjectCreatedEndingPage(5);
+		// addPage(projectedCreatedPage);
+		this.totalPages = 1;
 	}
 
 	@Override

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserWelcomePage.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserWelcomePage.java
@@ -1,14 +1,14 @@
 package nl.tudelft.watchdog.eclipse.ui.wizards.userregistration;
 
-import nl.tudelft.watchdog.eclipse.ui.util.BrowserOpenerSelection;
-import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
-import nl.tudelft.watchdog.eclipse.ui.wizards.WelcomePageBase;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
+
+import nl.tudelft.watchdog.eclipse.ui.util.BrowserOpenerSelection;
+import nl.tudelft.watchdog.eclipse.ui.util.UIUtils;
+import nl.tudelft.watchdog.eclipse.ui.wizards.WelcomePageBase;
 
 /**
  * The first page of the {@link UserProjectRegistrationWizard}. It asks the
@@ -23,8 +23,9 @@ public class UserWelcomePage extends WelcomePageBase {
 	/** Constructor. */
 	UserWelcomePage() {
 		super("Welcome to WatchDog!", 1);
-		setDescription("This wizard guides you through the setup of a WatchDog.\nPlease register, if you want to get your online report.");
-		welcomeTitle = "Welcome! Registration is fun and takes just 3 minutes!";
+		setDescription(
+				"You have successfully registered your project with WatchDog.");
+		welcomeTitle = "Welcome!";
 		welcomeText = "";
 		labelText = "Your WatchDog User-ID: ";
 		inputToolTip = "The User-ID we sent you upon your first WatchDog registration.";
@@ -42,8 +43,8 @@ public class UserWelcomePage extends WelcomePageBase {
 		Composite topContainer = UIUtils.createFullGridedComposite(parent, 1);
 
 		createWatchDogDescription(topContainer);
+		createSurveyLink(topContainer);
 		createLogoRow(topContainer);
-		createQuestionComposite(topContainer);
 
 		setControl(topContainer);
 		setPageComplete(false);
@@ -62,14 +63,25 @@ public class UserWelcomePage extends WelcomePageBase {
 		return composite;
 	}
 
+	private Composite createSurveyLink(Composite parent) {
+		Composite composite = UIUtils.createFullGridedComposite(parent, 1);
+
+		UIUtils.createBoldLabel(
+				"Please help us by spending at most 5 minutes on a survey:",
+				composite);
+		UIUtils.createStartDebugSurveyLink(composite);
+
+		return composite;
+	}
+
 	@Override
 	public void setVisible(boolean visible) {
 		super.setVisible(visible);
 		if (visible) {
+			welcomeTextLabel.setText(
+					"WatchDog is a free, open-source plugin that tells how you code your software.");
 			welcomeTextLabel
-					.setText("WatchDog is a free, open-source plugin that tells how you code your software.");
-			welcomeTextLabel.setLayoutData(new GridData(
-					GridData.FILL_HORIZONTAL));
+					.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 			welcomeTextLabel.getParent().layout();
 			welcomeTextLabel.getParent().update();
 

--- a/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserWelcomePage.java
+++ b/WatchDogEclipsePlugin/WatchDog/src/nl/tudelft/watchdog/eclipse/ui/wizards/userregistration/UserWelcomePage.java
@@ -24,7 +24,7 @@ public class UserWelcomePage extends WelcomePageBase {
 	UserWelcomePage() {
 		super("Welcome to WatchDog!", 1);
 		setDescription(
-				"You have successfully registered your project with WatchDog.");
+				"Please register your project with WatchDog in order to start collecting data.");
 		welcomeTitle = "Welcome!";
 		welcomeText = "";
 		labelText = "Your WatchDog User-ID: ";
@@ -43,11 +43,11 @@ public class UserWelcomePage extends WelcomePageBase {
 		Composite topContainer = UIUtils.createFullGridedComposite(parent, 1);
 
 		createWatchDogDescription(topContainer);
-		createSurveyLink(topContainer);
+		createRegistrationInfoLabel(topContainer);
 		createLogoRow(topContainer);
 
 		setControl(topContainer);
-		setPageComplete(false);
+		setPageComplete(true);
 	}
 
 	private Composite createWatchDogDescription(Composite parent) {
@@ -63,13 +63,12 @@ public class UserWelcomePage extends WelcomePageBase {
 		return composite;
 	}
 
-	private Composite createSurveyLink(Composite parent) {
+	private Composite createRegistrationInfoLabel(Composite parent) {
 		Composite composite = UIUtils.createFullGridedComposite(parent, 1);
 
 		UIUtils.createBoldLabel(
-				"Please help us by spending at most 5 minutes on a survey:",
+				"By clicking next, an anonymous registration will be performed for you and your project.",
 				composite);
-		UIUtils.createStartDebugSurveyLink(composite);
 
 		return composite;
 	}

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/WatchDogStartUp.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/WatchDogStartUp.java
@@ -127,8 +127,10 @@ public class WatchDogStartUp implements ProjectComponent {
         }
 
         UserProjectRegistrationWizard wizard = new UserProjectRegistrationWizard("User and Project Registration", project);
-        wizard.show();
-        if (wizard.getExitCode() == DialogWrapper.CANCEL_EXIT_CODE) {
+        makeSilentRegistration();
+        if (userExists() && projectExists()) {
+            wizard.show();
+        } else {
             if (Messages.YES == Messages.showYesNoDialog(WATCHDOG_UNREGISTERED_WARNING, "WatchDog is not registered!", Messages.getQuestionIcon())) {
                 makeSilentRegistration();
             } else {
@@ -136,6 +138,18 @@ public class WatchDogStartUp implements ProjectComponent {
                 preferences.registerProjectUse(project.getName(), false);
             }
         }
+    }
+
+    private boolean userExists() {
+        Preferences preferences = Preferences.getInstance();
+        return preferences.getUserId() != null
+                && !preferences.getUserId().isEmpty();
+    }
+
+    private boolean projectExists() {
+        ProjectPreferenceSetting setting = WatchDogGlobals.getPreferences()
+                .getOrCreateProjectSetting(project.getName());
+        return !WatchDogUtils.isEmpty(setting.projectId);
     }
 
     private void makeSilentRegistration() {

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/RegistrationWizardBase.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/RegistrationWizardBase.java
@@ -52,7 +52,7 @@ public abstract class RegistrationWizardBase extends AbstractWizard<WizardStep> 
     /**
      * Project registration completed.
      */
-    protected ProjectCreatedEndingStep projectedCreatedStep;
+    protected ProjectCreatedEndingStep projectCreatedStep;
 
     /**
      * Constructor.
@@ -105,9 +105,9 @@ public abstract class RegistrationWizardBase extends AbstractWizard<WizardStep> 
     }
 
     public void performFinish() {
-        Preferences preferences = Preferences.getInstance();
-        preferences.registerProjectId(WatchDogUtils.getProjectName(), projectId);
-        preferences.registerProjectUse(WatchDogUtils.getProjectName(), true);
+//        Preferences preferences = Preferences.getInstance();
+//        preferences.registerProjectId(WatchDogUtils.getProjectName(), projectId);
+//        preferences.registerProjectUse(WatchDogUtils.getProjectName(), true);
         return;
     }
 

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/RegistrationWizardBase.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/RegistrationWizardBase.java
@@ -105,9 +105,6 @@ public abstract class RegistrationWizardBase extends AbstractWizard<WizardStep> 
     }
 
     public void performFinish() {
-//        Preferences preferences = Preferences.getInstance();
-//        preferences.registerProjectId(WatchDogUtils.getProjectName(), projectId);
-//        preferences.registerProjectUse(WatchDogUtils.getProjectName(), true);
         return;
     }
 

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/WelcomeStepBase.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/WelcomeStepBase.java
@@ -197,7 +197,7 @@ public abstract class WelcomeStepBase extends WizardStep {
 
     @Override
     public boolean canFinish() {
-        return true;
+        return false;
     }
 
 }

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/WelcomeStepBase.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/WelcomeStepBase.java
@@ -197,7 +197,7 @@ public abstract class WelcomeStepBase extends WizardStep {
 
     @Override
     public boolean canFinish() {
-        return false;
+        return true;
     }
 
 }

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/WizardStep.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/WizardStep.java
@@ -196,7 +196,9 @@ public abstract class WizardStep implements Step {
 	/** Creates message on failure. */
 	public static void createFailureMessage(JPanel parent, String title,
 			String message) {
-		UIUtils.createBoldLabel(parent, title);
+        if (title != null && !title.isEmpty()) {
+            UIUtils.createBoldLabel(parent, title);
+        }
         JPanel innerParent = UIUtils.createFlowJPanelLeft(parent);
 		UIUtils.createLogo(innerParent, "/images/errormark.png");
 		UIUtils.createLabel(innerParent, message);
@@ -205,12 +207,16 @@ public abstract class WizardStep implements Step {
 	/** Creates message on success. */
 	public static void createSuccessMessage(JPanel parent, String title,
 			String message, String id) {
-		UIUtils.createBoldLabel(parent, title);
+        if (title != null && !title.isEmpty()) {
+            UIUtils.createBoldLabel(parent, title);
+        }
 		JPanel innerParent = UIUtils.createFlowJPanelLeft(parent);
 		UIUtils.createLogo(innerParent, "/images/checkmark.png");
 		JPanel displayInformation = UIUtils.createFlowJPanelLeft(innerParent);
 		UIUtils.createLabel(displayInformation, message);
-		UIUtils.createTextField(displayInformation, id);
+        if (id != null) {
+            UIUtils.createTextField(displayInformation, id);
+        }
 	}
 
     protected void createHeader(JComponent parent) {

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/projectregistration/ProjectCreatedEndingStep.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/projectregistration/ProjectCreatedEndingStep.java
@@ -1,18 +1,11 @@
 package nl.tudelft.watchdog.intellij.ui.wizards.projectregistration;
 
-import nl.tudelft.watchdog.core.logic.network.JsonTransferer;
-import nl.tudelft.watchdog.core.logic.network.ServerCommunicationException;
 import nl.tudelft.watchdog.core.util.WatchDogGlobals;
-import nl.tudelft.watchdog.intellij.ui.preferences.Preferences;
+import nl.tudelft.watchdog.intellij.WatchDogStartUp;
 import nl.tudelft.watchdog.intellij.ui.util.UIUtils;
-import nl.tudelft.watchdog.core.ui.wizards.Project;
 import nl.tudelft.watchdog.intellij.ui.wizards.RegistrationEndingStepBase;
 import nl.tudelft.watchdog.intellij.ui.wizards.RegistrationWizardBase;
 import nl.tudelft.watchdog.intellij.ui.wizards.WizardStep;
-import nl.tudelft.watchdog.intellij.ui.wizards.userregistration.UserRegistrationStep;
-import nl.tudelft.watchdog.intellij.ui.wizards.userregistration.UserProjectRegistrationWizard;
-import nl.tudelft.watchdog.core.util.WatchDogLogger;
-import org.apache.commons.lang.WordUtils;
 
 
 import javax.swing.*;
@@ -30,68 +23,29 @@ public class ProjectCreatedEndingStep extends RegistrationEndingStepBase {
      */
     public ProjectCreatedEndingStep(int pageNumber, RegistrationWizardBase wizard) {
         super("Project-ID created.", pageNumber, wizard);
-        concludingMessage = "<html>You can change these and other WatchDog settings in the IntelliJ Settings.<br>"
-                + ProjectIdEnteredEndingStep.ENCOURAGING_END_MESSAGE;
+        concludingMessage = ProjectIdEnteredEndingStep.ENCOURAGING_END_MESSAGE;
         setTitle(windowTitle);
     }
 
     @Override
     protected void makeRegistration() {
-        Project project = new Project(Preferences.getInstance().getUserId());
-
-        ProjectSliderStep sliderStep;
-        ProjectRegistrationStep projectStep = getWizard().projectRegistrationStep;
-        if (!getWizard().projectRegistrationStep.shouldSkipProjectSliderStep()) {
-            sliderStep = getWizard().projectSliderStep;
-            project.productionPercentage = sliderStep.percentageProductionSlider.getValue();
-            project.useJunitOnlyForUnitTesting = sliderStep
-                    .usesJunitForUnitTestingOnly();
-            project.followTestDrivenDesign = sliderStep.usesTestDrivenDesing();
-        }
-
-        // initialize from projectPage
-        project.belongToASingleSoftware = !projectStep.noSingleProjectCheck.isSelected();
-        project.name = projectStep.projectNameInput.getText();
-        project.website = projectStep.projectWebsite.getText();
-        project.usesContinuousIntegration = projectStep.usesContinuousIntegration();
-        project.usesJunit = projectStep.usesJunit();
-        project.usesOtherTestingFrameworks = projectStep
-                .usesOtherTestingFrameworks();
-        project.usesOtherTestingForms = projectStep.usesOtherTestingForms();
-
         windowTitle = "Registration Summary";
-
-        try {
-            id = new JsonTransferer().registerNewProject(project);
-        } catch (ServerCommunicationException exception) {
+        messageTitle = "";
+        if (WatchDogStartUp.makeSilentRegistration()) {
+            successfulRegistration = true;
+            messageBody = "New user and project successfully registered!";
+        } else {
             successfulRegistration = false;
-            messageTitle = "Problem creating new project!";
-            messageBody = "<html>" + WordUtils.wrap(exception.getMessage(), 100, "<br>", true);
-            messageBody += "<br>Are you connected to the internet, and is port 80 open?";
-            messageBody += "<br>Please contact us via www.testroots.org. <br>We'll troubleshoot the issue!</html>";
-            WatchDogLogger.getInstance().logSevere(exception);
-            return;
+            messageBody = "Registration failed! Do you have an internet connection?";
         }
-
-        successfulRegistration = true;
-
-        getWizard().setProjectId(id);
-
-        messageTitle = "New project registered!";
-        messageBody = "Your new project id is registered: ";
     }
 
     private void createPageContent(JPanel parent) {
-        if (isThisProjectWizard()) {
-            createProjectRegistrationSummary(parent);
-        } else {
-            UserProjectRegistrationWizard wizard = (UserProjectRegistrationWizard) getWizard();
-            UserRegistrationStep userRegistrationStep = wizard.userRegistrationStep;
-            if (wizard.userWelcomeStep.getRegisterNewId()) {
-                createDebugSurveyInfo(parent);
-                userRegistrationStep.createUserRegistrationSummary(parent);
-            }
-            createProjectRegistrationSummary(parent);
+        setTitle(windowTitle);
+        createUserAndProjectRegistrationSummary(parent);
+        createDebugSurveyInfo(parent);
+        if (successfulRegistration) {
+            UIUtils.createLabel(parent, concludingMessage);
         }
     }
 
@@ -104,19 +58,13 @@ public class ProjectCreatedEndingStep extends RegistrationEndingStepBase {
         UIUtils.createStartDebugSurveyLink(parent);
     }
 
-    private void createProjectRegistrationSummary(JPanel parent) {
+    private void createUserAndProjectRegistrationSummary(JPanel parent) {
         if (successfulRegistration) {
-            WizardStep.createSuccessMessage(parent, messageTitle, messageBody, id);
-            UIUtils.createLabel(parent, concludingMessage);
+            WizardStep.createSuccessMessage(parent, messageTitle, messageBody, null);
             getWizard().getCancelButton().setEnabled(false);
         } else {
             WizardStep.createFailureMessage(parent, messageTitle, messageBody);
         }
-    }
-
-    private boolean isThisProjectWizard() {
-        RegistrationWizardBase wizard = getWizard();
-        return wizard instanceof ProjectRegistrationWizard;
     }
 
     @Override

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/projectregistration/ProjectRegistrationWizard.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/projectregistration/ProjectRegistrationWizard.java
@@ -25,8 +25,8 @@ public class ProjectRegistrationWizard extends RegistrationWizardBase {
 		addStep(projectSliderStep);
 		existingProjectIdStep = new ProjectIdEnteredEndingStep(3, this);
 		addStep(existingProjectIdStep);
-		projectedCreatedStep = new ProjectCreatedEndingStep(4, this);
-		addStep(projectedCreatedStep);
+		projectCreatedStep = new ProjectCreatedEndingStep(4, this);
+		addStep(projectCreatedStep);
 		this.totalSteps = 4;
 	}
 
@@ -39,10 +39,10 @@ public class ProjectRegistrationWizard extends RegistrationWizardBase {
 		}
 		if (myCurrentStep == projectRegistrationStep.getStepId()
 				&& projectRegistrationStep.shouldSkipProjectSliderStep()) {
-			return projectedCreatedStep.getStepId();
+			return projectCreatedStep.getStepId();
 		}
 		if (myCurrentStep == projectSliderStep.getStepId()) {
-			return projectedCreatedStep.getStepId();
+			return projectCreatedStep.getStepId();
 		}
 		return super.getNextStep(page);
 	}
@@ -53,7 +53,7 @@ public class ProjectRegistrationWizard extends RegistrationWizardBase {
         if (myCurrentStep == existingProjectIdStep.getStepId()) {
             return projectWelcomeStep.getStepId();
         }
-        if(myCurrentStep == projectedCreatedStep.getStepId() && projectRegistrationStep.shouldSkipProjectSliderStep()) {
+        if(myCurrentStep == projectCreatedStep.getStepId() && projectRegistrationStep.shouldSkipProjectSliderStep()) {
             return projectRegistrationStep.getStepId();
         }
         return super.getPreviousStep(step);

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -44,18 +44,6 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
     public void addSteps() {
 		userWelcomeStep = new UserWelcomeStep(0, this);
 		addStep(userWelcomeStep);
-//		userRegistrationStep = new UserRegistrationStep(1, this);
-//		addStep(userRegistrationStep);
-//		existingUserEndingStep = new UserIdEnteredEndingStep(2, this);
-//		addStep(existingUserEndingStep);
-//		existingProjectIdStep = new ProjectIdEnteredEndingStep(3, this);
-//		addStep(existingProjectIdStep);
-//		projectWelcomeStep = new ProjectWelcomeStep(4, this);
-//		addStep(projectWelcomeStep);
-//		projectRegistrationStep = new ProjectRegistrationStep(5, this);
-//		addStep(projectRegistrationStep);
-//		projectSliderStep = new ProjectSliderStep(6, this);
-//		addStep(projectSliderStep);
 		projectCreatedStep = new ProjectCreatedEndingStep(1, this);
 		addStep(projectCreatedStep);
 		this.totalSteps = 2;

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -56,60 +56,27 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
 //		addStep(projectRegistrationStep);
 //		projectSliderStep = new ProjectSliderStep(6, this);
 //		addStep(projectSliderStep);
-//		projectedCreatedStep = new ProjectCreatedEndingStep(7, this);
-//		addStep(projectedCreatedStep);
-		this.totalSteps = 1;
+		projectCreatedStep = new ProjectCreatedEndingStep(1, this);
+		addStep(projectCreatedStep);
+		this.totalSteps = 2;
 	}
 
     @Override
 	public int getNextStep(int step) {
         if(this.getCurrentStepObject().canFinish()) return getCurrentStep();
-//		if (myCurrentStep == userWelcomeStep.getStepId()
-//				&& !userWelcomeStep.getRegisterNewId()) {
-//			return existingUserEndingStep.getStepId();
-//		}
-//		if (myCurrentStep == existingUserEndingStep.getStepId()) {
-//			return projectWelcomeStep.getStepId();
-//		}
-//		if (myCurrentStep == userRegistrationStep.getStepId()) {
-//			return projectRegistrationStep.getStepId();
-//		}
-//		if (myCurrentStep == projectWelcomeStep.getStepId()
-//				&& !projectWelcomeStep.getRegisterNewId()) {
-//			return existingProjectIdStep.getStepId();
-//		}
-//		if (myCurrentStep == projectRegistrationStep.getStepId()
-//				&& projectRegistrationStep.shouldSkipProjectSliderStep()) {
-//			return projectedCreatedStep.getStepId();
-//		}
-//		if (myCurrentStep == projectSliderStep.getStepId()) {
-//			return projectedCreatedStep.getStepId();
-//		}
+		if (myCurrentStep == userWelcomeStep.getStepId()) {
+			return projectCreatedStep.getStepId();
+		}
 		return super.getNextStep(step);
 	}
 
     @Override
 	public int getPreviousStep(int step) {
         if(this.getCurrentStepObject().canFinish()) return -1;
-//		if (myCurrentStep == existingUserEndingStep.getStepId()
-//				&& !userWelcomeStep.getRegisterNewId()) {
-//			return userWelcomeStep.getStepId();
-//		}
-//		if (myCurrentStep == projectWelcomeStep.getStepId()) {
-//			return existingUserEndingStep.getStepId();
-//		}
-//		if (myCurrentStep == existingProjectIdStep.getStepId()
-//				&& !projectWelcomeStep.getRegisterNewId()) {
-//			return projectWelcomeStep.getStepId();
-//		}
-//		if (myCurrentStep == projectRegistrationStep.getStepId()) {
-//			// Disable going back if a new user id is being created.
-//			return userWelcomeStep.getRegisterNewId() ? -1
-//					: projectWelcomeStep.getStepId();
-//		}
-//        if(myCurrentStep == projectedCreatedStep.getStepId() && projectRegistrationStep.shouldSkipProjectSliderStep()) {
-//            return projectRegistrationStep.getStepId();
-//        }
+		if (myCurrentStep == projectCreatedStep.getStepId()) {
+			// Disable going back.
+			return -1;
+		}
 		return super.getPreviousStep(step);
 	}
 

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -12,19 +12,25 @@ import org.jetbrains.annotations.Nullable;
  */
 public class UserProjectRegistrationWizard extends RegistrationWizardBase {
 
-	/** The first step in the wizard. */
-	public UserWelcomeStep userWelcomeStep;
+    /**
+     * The first step in the wizard.
+     */
+    public UserWelcomeStep userWelcomeStep;
 
-	/** The step with all the actual user info (name, email, etc.) on it. */
-	public UserRegistrationStep userRegistrationStep;
+    /**
+     * The step with all the actual user info (name, email, etc.) on it.
+     */
+    public UserRegistrationStep userRegistrationStep;
 
-	/** When a user already exists ... */
-	/* package */UserIdEnteredEndingStep existingUserEndingStep;
+    /**
+     * When a user already exists ...
+     */
+    /* package */ UserIdEnteredEndingStep existingUserEndingStep;
 
-	/**
-	 * The userid, either entered on this step or as retrieved by the server.
-	 */
-	/* package */String userid;
+    /**
+     * The userid, either entered on this step or as retrieved by the server.
+     */
+	/* package */ String userid;
 
     /**
      * Constructor.
@@ -42,30 +48,34 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
     }
 
     public void addSteps() {
-		userWelcomeStep = new UserWelcomeStep(0, this);
-		addStep(userWelcomeStep);
-		projectCreatedStep = new ProjectCreatedEndingStep(1, this);
-		addStep(projectCreatedStep);
-		this.totalSteps = 2;
-	}
+        userWelcomeStep = new UserWelcomeStep(0, this);
+        addStep(userWelcomeStep);
+        projectCreatedStep = new ProjectCreatedEndingStep(1, this);
+        addStep(projectCreatedStep);
+        this.totalSteps = 2;
+    }
 
     @Override
-	public int getNextStep(int step) {
-        if(this.getCurrentStepObject().canFinish()) return getCurrentStep();
-		if (myCurrentStep == userWelcomeStep.getStepId()) {
-			return projectCreatedStep.getStepId();
-		}
-		return super.getNextStep(step);
-	}
+    public int getNextStep(int step) {
+        if (this.getCurrentStepObject().canFinish()) {
+            return getCurrentStep();
+        }
+        if (myCurrentStep == userWelcomeStep.getStepId()) {
+            return projectCreatedStep.getStepId();
+        }
+        return super.getNextStep(step);
+    }
 
     @Override
-	public int getPreviousStep(int step) {
-        if(this.getCurrentStepObject().canFinish()) return -1;
-		if (myCurrentStep == projectCreatedStep.getStepId()) {
-			// Disable going back.
-			return -1;
-		}
-		return super.getPreviousStep(step);
-	}
+    public int getPreviousStep(int step) {
+        if (this.getCurrentStepObject().canFinish()) {
+            return -1;
+        }
+        if (myCurrentStep == projectCreatedStep.getStepId()) {
+            // Disable going back.
+            return -1;
+        }
+        return super.getPreviousStep(step);
+    }
 
 }

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserProjectRegistrationWizard.java
@@ -44,72 +44,72 @@ public class UserProjectRegistrationWizard extends RegistrationWizardBase {
     public void addSteps() {
 		userWelcomeStep = new UserWelcomeStep(0, this);
 		addStep(userWelcomeStep);
-		userRegistrationStep = new UserRegistrationStep(1, this);
-		addStep(userRegistrationStep);
-		existingUserEndingStep = new UserIdEnteredEndingStep(2, this);
-		addStep(existingUserEndingStep);
-		existingProjectIdStep = new ProjectIdEnteredEndingStep(3, this);
-		addStep(existingProjectIdStep);
-		projectWelcomeStep = new ProjectWelcomeStep(4, this);
-		addStep(projectWelcomeStep);
-		projectRegistrationStep = new ProjectRegistrationStep(5, this);
-		addStep(projectRegistrationStep);
-		projectSliderStep = new ProjectSliderStep(6, this);
-		addStep(projectSliderStep);
-		projectedCreatedStep = new ProjectCreatedEndingStep(7, this);
-		addStep(projectedCreatedStep);
-		this.totalSteps = 5;
+//		userRegistrationStep = new UserRegistrationStep(1, this);
+//		addStep(userRegistrationStep);
+//		existingUserEndingStep = new UserIdEnteredEndingStep(2, this);
+//		addStep(existingUserEndingStep);
+//		existingProjectIdStep = new ProjectIdEnteredEndingStep(3, this);
+//		addStep(existingProjectIdStep);
+//		projectWelcomeStep = new ProjectWelcomeStep(4, this);
+//		addStep(projectWelcomeStep);
+//		projectRegistrationStep = new ProjectRegistrationStep(5, this);
+//		addStep(projectRegistrationStep);
+//		projectSliderStep = new ProjectSliderStep(6, this);
+//		addStep(projectSliderStep);
+//		projectedCreatedStep = new ProjectCreatedEndingStep(7, this);
+//		addStep(projectedCreatedStep);
+		this.totalSteps = 1;
 	}
 
     @Override
 	public int getNextStep(int step) {
         if(this.getCurrentStepObject().canFinish()) return getCurrentStep();
-		if (myCurrentStep == userWelcomeStep.getStepId()
-				&& !userWelcomeStep.getRegisterNewId()) {
-			return existingUserEndingStep.getStepId();
-		}
-		if (myCurrentStep == existingUserEndingStep.getStepId()) {
-			return projectWelcomeStep.getStepId();
-		}
-		if (myCurrentStep == userRegistrationStep.getStepId()) {
-			return projectRegistrationStep.getStepId();
-		}
-		if (myCurrentStep == projectWelcomeStep.getStepId()
-				&& !projectWelcomeStep.getRegisterNewId()) {
-			return existingProjectIdStep.getStepId();
-		}
-		if (myCurrentStep == projectRegistrationStep.getStepId()
-				&& projectRegistrationStep.shouldSkipProjectSliderStep()) {
-			return projectedCreatedStep.getStepId();
-		}
-		if (myCurrentStep == projectSliderStep.getStepId()) {
-			return projectedCreatedStep.getStepId();
-		}
+//		if (myCurrentStep == userWelcomeStep.getStepId()
+//				&& !userWelcomeStep.getRegisterNewId()) {
+//			return existingUserEndingStep.getStepId();
+//		}
+//		if (myCurrentStep == existingUserEndingStep.getStepId()) {
+//			return projectWelcomeStep.getStepId();
+//		}
+//		if (myCurrentStep == userRegistrationStep.getStepId()) {
+//			return projectRegistrationStep.getStepId();
+//		}
+//		if (myCurrentStep == projectWelcomeStep.getStepId()
+//				&& !projectWelcomeStep.getRegisterNewId()) {
+//			return existingProjectIdStep.getStepId();
+//		}
+//		if (myCurrentStep == projectRegistrationStep.getStepId()
+//				&& projectRegistrationStep.shouldSkipProjectSliderStep()) {
+//			return projectedCreatedStep.getStepId();
+//		}
+//		if (myCurrentStep == projectSliderStep.getStepId()) {
+//			return projectedCreatedStep.getStepId();
+//		}
 		return super.getNextStep(step);
 	}
 
     @Override
 	public int getPreviousStep(int step) {
         if(this.getCurrentStepObject().canFinish()) return -1;
-		if (myCurrentStep == existingUserEndingStep.getStepId()
-				&& !userWelcomeStep.getRegisterNewId()) {
-			return userWelcomeStep.getStepId();
-		}
-		if (myCurrentStep == projectWelcomeStep.getStepId()) {
-			return existingUserEndingStep.getStepId();
-		}
-		if (myCurrentStep == existingProjectIdStep.getStepId()
-				&& !projectWelcomeStep.getRegisterNewId()) {
-			return projectWelcomeStep.getStepId();
-		}
-		if (myCurrentStep == projectRegistrationStep.getStepId()) {
-			// Disable going back if a new user id is being created.
-			return userWelcomeStep.getRegisterNewId() ? -1
-					: projectWelcomeStep.getStepId();
-		}
-        if(myCurrentStep == projectedCreatedStep.getStepId() && projectRegistrationStep.shouldSkipProjectSliderStep()) {
-            return projectRegistrationStep.getStepId();
-        }
+//		if (myCurrentStep == existingUserEndingStep.getStepId()
+//				&& !userWelcomeStep.getRegisterNewId()) {
+//			return userWelcomeStep.getStepId();
+//		}
+//		if (myCurrentStep == projectWelcomeStep.getStepId()) {
+//			return existingUserEndingStep.getStepId();
+//		}
+//		if (myCurrentStep == existingProjectIdStep.getStepId()
+//				&& !projectWelcomeStep.getRegisterNewId()) {
+//			return projectWelcomeStep.getStepId();
+//		}
+//		if (myCurrentStep == projectRegistrationStep.getStepId()) {
+//			// Disable going back if a new user id is being created.
+//			return userWelcomeStep.getRegisterNewId() ? -1
+//					: projectWelcomeStep.getStepId();
+//		}
+//        if(myCurrentStep == projectedCreatedStep.getStepId() && projectRegistrationStep.shouldSkipProjectSliderStep()) {
+//            return projectRegistrationStep.getStepId();
+//        }
 		return super.getPreviousStep(step);
 	}
 

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserWelcomeStep.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserWelcomeStep.java
@@ -18,8 +18,8 @@ public class UserWelcomeStep extends WelcomeStepBase {
     public UserWelcomeStep(int stepNumber, RegistrationWizardBase wizard) {
 		super("Welcome to WatchDog!", stepNumber, wizard);
         myIcon = IconLoader.getIcon("/images/user.png");
-		descriptionText = "<html>This wizard guides you through the setup of WatchDog Plugin.<br>Please register, so you can access your personal online report.";
-		welcomeDisplay = "Welcome! Registration is fun and takes just 3 minutes!";
+		descriptionText = "You have successfully registered your project with WatchDog.";
+		welcomeDisplay = "Welcome!";
 		welcomeText = "WatchDog is a free, open-source plugin that tells how you code your software.";
 		labelText = "Your WatchDog User-ID: ";
 		inputToolTip = "The User-ID we sent you upon your first WatchDog registration.";
@@ -53,8 +53,15 @@ public class UserWelcomeStep extends WelcomeStepBase {
         JPanel oneColumn = UIUtils.createVerticalBoxJPanel(topPanel);
         createHeader(oneColumn);
         createWatchDogDescription(oneColumn);
+        createSurveyLink(oneColumn);
         createLogoRow(oneColumn);
-        createQuestionJPanel(oneColumn);
-        setComplete(false);
+        setComplete(true);
+    }
+
+    private void createSurveyLink(JPanel parent) {
+        JPanel panel = UIUtils.createGridedJPanel(parent, 1);
+        UIUtils.createBoldLabel(panel, "Please help us by spending at most 5 minutes on a survey:");
+        UIUtils.createStartDebugSurveyLink(panel);
+        UIUtils.createLabel(panel, "");
     }
 }

--- a/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserWelcomeStep.java
+++ b/WatchDogIntelliJPlugin/WatchDog/src/nl/tudelft/watchdog/intellij/ui/wizards/userregistration/UserWelcomeStep.java
@@ -18,7 +18,7 @@ public class UserWelcomeStep extends WelcomeStepBase {
     public UserWelcomeStep(int stepNumber, RegistrationWizardBase wizard) {
 		super("Welcome to WatchDog!", stepNumber, wizard);
         myIcon = IconLoader.getIcon("/images/user.png");
-		descriptionText = "You have successfully registered your project with WatchDog.";
+		descriptionText = "Please register your project with WatchDog in order to start collecting data.";
 		welcomeDisplay = "Welcome!";
 		welcomeText = "WatchDog is a free, open-source plugin that tells how you code your software.";
 		labelText = "Your WatchDog User-ID: ";
@@ -53,15 +53,14 @@ public class UserWelcomeStep extends WelcomeStepBase {
         JPanel oneColumn = UIUtils.createVerticalBoxJPanel(topPanel);
         createHeader(oneColumn);
         createWatchDogDescription(oneColumn);
-        createSurveyLink(oneColumn);
+        createRegistrationInfoLabel(oneColumn);
         createLogoRow(oneColumn);
         setComplete(true);
     }
 
-    private void createSurveyLink(JPanel parent) {
+    private void createRegistrationInfoLabel(JPanel parent) {
         JPanel panel = UIUtils.createGridedJPanel(parent, 1);
-        UIUtils.createBoldLabel(panel, "Please help us by spending at most 5 minutes on a survey:");
-        UIUtils.createStartDebugSurveyLink(panel);
+        UIUtils.createBoldLabel(panel, "By clicking next, an anonymous registration will be performed for you and your project.");
         UIUtils.createLabel(panel, "");
     }
 }


### PR DESCRIPTION
Closes #257 

Now the wizards have two pages, the results are:

**Eclipse:**
![new wizard eclipse1](https://cloud.githubusercontent.com/assets/3593160/15213077/3224a9f6-1845-11e6-9e07-4c6f10695f61.png)
![new wizard eclipse2](https://cloud.githubusercontent.com/assets/3593160/15213081/33d26518-1845-11e6-899b-0ff55c7cdec2.png)

**IntelliJ:**
![new wizard ij1](https://cloud.githubusercontent.com/assets/3593160/15213099/4f51a402-1845-11e6-8eb7-4cb58d9fe070.png)
![new wizard ij2](https://cloud.githubusercontent.com/assets/3593160/15213102/509eecc0-1845-11e6-8216-51dd9a1b5c61.png)

The resulting code base is quite ugly, but that does not really matter IMO as we'll revert all of these changes later on.



