### PR TITLE
Use a single classLoader for loading the CheckStyle messages

### DIFF
--- a/core/src/nl/tudelft/watchdog/core/logic/ui/listeners/staticanalysis/CheckStyleChecksMessagesFetcher.java
+++ b/core/src/nl/tudelft/watchdog/core/logic/ui/listeners/staticanalysis/CheckStyleChecksMessagesFetcher.java
@@ -46,7 +46,7 @@ public class CheckStyleChecksMessagesFetcher {
 
     public static void addCheckStyleMessagesToBundle(ClassLoader checkStylePluginClassLoader)
                     throws ClassNotFoundException, IllegalAccessException, NoSuchFieldException, IOException {
-        final Map<String, String> nameToModuleName = getModuleMapFromPackageObjectFactory(checkStylePluginClassLoader);
+        Map<String, String> nameToModuleName = getModuleMapFromPackageObjectFactory(checkStylePluginClassLoader);
 
         addMessagesToCheckStyleBundleForLoadedChecks(nameToModuleName, checkStylePluginClassLoader);
     }
@@ -55,10 +55,10 @@ public class CheckStyleChecksMessagesFetcher {
     private static Map<String, String> getModuleMapFromPackageObjectFactory(ClassLoader checkStylePackageLoaderClassLoader)
             throws ClassNotFoundException, IllegalAccessException, NoSuchFieldException {
 
-        final Class<?> packageObjectFactoryClass = checkStylePackageLoaderClassLoader
+        Class<?> packageObjectFactoryClass = checkStylePackageLoaderClassLoader
                 .loadClass("com.puppycrawl.tools.checkstyle.PackageObjectFactory");
 
-        final Field packageObjectFactoryMapField = packageObjectFactoryClass.getDeclaredField("NAME_TO_FULL_MODULE_NAME");
+        Field packageObjectFactoryMapField = packageObjectFactoryClass.getDeclaredField("NAME_TO_FULL_MODULE_NAME");
         packageObjectFactoryMapField.setAccessible(true);
 
         return (Map<String, String>) packageObjectFactoryMapField.get(null);

--- a/core/src/nl/tudelft/watchdog/core/logic/ui/listeners/staticanalysis/CheckStyleChecksMessagesFetcher.java
+++ b/core/src/nl/tudelft/watchdog/core/logic/ui/listeners/staticanalysis/CheckStyleChecksMessagesFetcher.java
@@ -18,16 +18,15 @@ import nl.tudelft.watchdog.core.util.WatchDogUtilsBase;
  * a {@link ClassLoader}. In Eclipse, we do not know whether the user has installed the Checkstyle plugin at all,
  * which means we can also only dynamically depend on the Checkstyle classes.
  *
- * We need multiple classloaders to load the correct files to load the CheckStyle class files and one
- * to load the CheckStyle message.properties files. The first classloader is created in the IntelliJ CheckStyle plugin.
+ * We need a classloader to load the correct files to load the CheckStyle class files and
+ * to load the CheckStyle message.properties files. The classloader is created in the IntelliJ CheckStyle plugin.
  * This plugin is configured to load several jars, including the CheckStyle jar. This loader therefore has access to
  * CheckStyle classes. In the code below, this loader is called <code>checkStylePluginClassLoader</code>.
  *
  * Besides the actual classes, other configuration resources from Checkstyle must also be loaded. This configuration
  * however partly resides in the CheckStyle jar. Other files reside in the IntelliJ plugin. To that end, the IntelliJ
- * plugin implements a so-called "csaccess" layer. This layer has its own classloader and has access to:
+ * plugin implements a so-called "csaccess" layer. This layer uses the same classloader and has access to:
  * 1. the csaccess files as implemented by the plugin and 2. the resources available in CheckStyle.
- * This loader is named <code>checkStylePackageLoaderClassLoader</code> in the code below.
  *
  * The overall implementation design is therefore as follows: Load the configuration and other plugin-relevant
  * classes in our current classloader. Once we got the relevant classes, obtain the classloader created by
@@ -35,11 +34,8 @@ import nl.tudelft.watchdog.core.util.WatchDogUtilsBase;
  * all checks, we obtain their corresponding messages.
  *
  * Since these messages are stored in resources named "messages.properties" and based on the packagename,
- * we need to use the last classloader to fetch the resources from there. We process the resources in
- * {@link #addMessagesToCheckStyleBundleForLoadedChecks(ClassLoader, Map, ClassLoader)}.
- * Observe that this method takes 2 classloaders, as we need both the classes (to obtain the resource path),
- * e.g. the <code>checkStylePluginClassLoader</code> and the other one to obtain the cactual resource, e.g.
- * <code>checkStylePackageLoaderClassLoader</code>.
+ * we need to use the plugin classloader to fetch the resources from there. We process the resources in
+ * {@link #addMessagesToCheckStyleBundleForLoadedChecks(Map, ClassLoader)}.
  *
  * If you need to update this code, think carefully about which classloader can load what.
  * When we originally wrote this class, it was mostly based on
@@ -48,17 +44,11 @@ import nl.tudelft.watchdog.core.util.WatchDogUtilsBase;
  */
 public class CheckStyleChecksMessagesFetcher {
 
-    public static void addCheckStyleMessagesToBundle(ClassLoader classLoader)
-            throws ClassNotFoundException, IllegalAccessException, NoSuchFieldException, IOException {
-        addCheckStyleMessagesToBundle(classLoader, classLoader);
-    }
-
-    public static void addCheckStyleMessagesToBundle(ClassLoader checkStylePackageLoaderClassLoader,
-            ClassLoader checkStylePluginClassLoader)
+    public static void addCheckStyleMessagesToBundle(ClassLoader checkStylePluginClassLoader)
                     throws ClassNotFoundException, IllegalAccessException, NoSuchFieldException, IOException {
-        final Map<String, String> nameToModuleName = getModuleMapFromPackageObjectFactory(checkStylePackageLoaderClassLoader);
+        final Map<String, String> nameToModuleName = getModuleMapFromPackageObjectFactory(checkStylePluginClassLoader);
 
-        addMessagesToCheckStyleBundleForLoadedChecks(checkStylePackageLoaderClassLoader, nameToModuleName, checkStylePluginClassLoader);
+        addMessagesToCheckStyleBundleForLoadedChecks(nameToModuleName, checkStylePluginClassLoader);
     }
 
     @SuppressWarnings("unchecked")
@@ -75,14 +65,13 @@ public class CheckStyleChecksMessagesFetcher {
     }
 
     private static void addMessagesToCheckStyleBundleForLoadedChecks(
-            ClassLoader checkStylePackageLoaderClassLoader,
             Map<String, String> nameToModuleName,
             ClassLoader checkStylePluginClassLoader) throws IOException {
         // Use a map to have distinct resource properties, to make sure we don't process messages double
         Map<String, String> resourceToPackage = new HashMap<>();
 
         nameToModuleName.values().stream()
-                .map(WatchDogUtilsBase.transformCheckedExceptionIntoUncheckedException(checkStylePackageLoaderClassLoader::loadClass))
+                .map(WatchDogUtilsBase.transformCheckedExceptionIntoUncheckedException(checkStylePluginClassLoader::loadClass))
                 // In case loading of the class failed, we have to filter the null value
                 .filter(Objects::nonNull)
                 .forEach(clazz -> {

--- a/intellij/src/nl/tudelft/watchdog/intellij/logic/ui/listeners/staticanalysis/CheckStyleStartup.java
+++ b/intellij/src/nl/tudelft/watchdog/intellij/logic/ui/listeners/staticanalysis/CheckStyleStartup.java
@@ -45,13 +45,7 @@ public class CheckStyleStartup implements ProjectComponent {
             } catch (Exception e) {
                 CheckstyleProjectService service = ServiceManager.getService(this.project, CheckstyleProjectService.class);
 
-                // This loader can load all checks as defined in CheckStyle
-                final ClassLoader checkStylePackageLoaderClassLoader = service.getCheckstyleInstance().getClass().getClassLoader();
-
-                // This loader is used to obtain the actual resources
-                final ClassLoader checkStylePluginClassLoader = getPluginCreatedClassLoaderFromService(service);
-
-                addCheckStyleMessagesToBundle(checkStylePackageLoaderClassLoader, checkStylePluginClassLoader);
+                addCheckStyleMessagesToBundle(getPluginCreatedClassLoaderFromService(service));
                 addMessagesForActiveConfiguration(service);
             }
 
@@ -64,10 +58,7 @@ public class CheckStyleStartup implements ProjectComponent {
     private void initComponentWithCheckstylePluginAPI() throws Exception {
         CheckstylePluginApi pluginApi = ServiceManager.getService(this.project, CheckstylePluginApi.class);
 
-        final ClassLoader checkstylePluginClassLoader = pluginApi.currentCheckstyleClassLoader();
-        final ClassLoader checkstylePackageLoaderClassLoader = ServiceManager.getService(this.project, CheckstyleProjectService.class).getCheckstyleInstance().getClass().getClassLoader();
-
-        addCheckStyleMessagesToBundle(checkstylePackageLoaderClassLoader, checkstylePluginClassLoader);
+        addCheckStyleMessagesToBundle(pluginApi.currentCheckstyleClassLoader());
         pluginApi.visitCurrentConfiguration(this::addMessagesForActiveConfiguration);
     }
 


### PR DESCRIPTION
I have had a chat with the IntelliJ Checkstyle plugin author and after some investigation we found out that the loader is now the same. They are no longer different. Therefore remove the "2-loader"-logic from the codebase, simplifying the implementation and remove some complications in the javadoc story.