### PR TITLE
Obtain document line number at moment of warning creation in IntelliJ

### DIFF
--- a/core/src/nl/tudelft/watchdog/core/logic/ui/listeners/staticanalysis/Warning.java
+++ b/core/src/nl/tudelft/watchdog/core/logic/ui/listeners/staticanalysis/Warning.java
@@ -16,8 +16,8 @@ public class Warning<T> implements Serializable {
 
 	private static final long serialVersionUID = -573132089990619360L;
 
-	@SerializedName("docline")
-	public final int docLineNumber;
+	@SerializedName("doctotal")
+	public final int docTotalLines;
 
 	@SerializedName("type")
 	public final T type;
@@ -31,12 +31,29 @@ public class Warning<T> implements Serializable {
 	@SerializedName("diff")
 	public final int secondsBetween;
 
-	public Warning(int docLineNumber, T type, int lineNumber, Date warningCreationTime) {
-		this(docLineNumber, type, lineNumber, warningCreationTime, -1);
+	/**
+	 * Create a warning in a document, without a difference in time of a previous warning event
+	 * (in the case this event is a warning deletion).
+	 * @param docTotalLines The total number of lines in the document at the moment the warning was created.
+	 * @param type The type of warning, could be a highlighter or the textual classification of the warning.
+	 * @param lineNumber The line number this warning was created on.
+	 * @param warningCreationTime The timestamp this warning was created at.
+	 */
+	public Warning(int docTotalLines, T type, int lineNumber, Date warningCreationTime) {
+		this(docTotalLines, type, lineNumber, warningCreationTime, -1);
 	}
 
-	public Warning(int docLineNumber, T type, int lineNumber, Date warningCreationTime, int secondsBetween) {
-		this.docLineNumber = docLineNumber;
+	/**
+	 * Create a warning in a document, including a difference in time of a previous warning event
+	 * (in the case this event is a warning deletion).
+	 * @param docTotalLines The total number of lines in the document at the moment the warning was created.
+	 * @param type The type of warning, could be a highlighter or the textual classification of the warning.
+	 * @param lineNumber The line number this warning was created on.
+	 * @param warningCreationTime The timestamp this warning was created at.
+	 * @param secondsBetween The number of seconds between a warning deletion and the original warning creation timestamp.
+	 */
+	public Warning(int docTotalLines, T type, int lineNumber, Date warningCreationTime, int secondsBetween) {
+		this.docTotalLines = docTotalLines;
 		this.type = type;
 		this.warningCreationTime = warningCreationTime;
 		this.secondsBetween = secondsBetween;

--- a/core/src/nl/tudelft/watchdog/core/logic/ui/listeners/staticanalysis/Warning.java
+++ b/core/src/nl/tudelft/watchdog/core/logic/ui/listeners/staticanalysis/Warning.java
@@ -14,28 +14,32 @@ import java.util.Date;
  */
 public class Warning<T> implements Serializable {
 
-    private static final long serialVersionUID = -573132089990619360L;
+	private static final long serialVersionUID = -573132089990619360L;
 
-    @SerializedName("type")
-    public final T type;
+	@SerializedName("docline")
+	public final int docLineNumber;
 
-    @SerializedName("line")
-    public final int lineNumber;
+	@SerializedName("type")
+	public final T type;
 
-    @SerializedName("time")
-    public final Date warningCreationTime;
+	@SerializedName("line")
+	public final int lineNumber;
 
-    @SerializedName("diff")
-    public final int secondsBetween;
+	@SerializedName("time")
+	public final Date warningCreationTime;
 
-    public Warning(T type, int lineNumber, Date warningCreationTime) {
-        this(type, lineNumber, warningCreationTime, -1);
-    }
+	@SerializedName("diff")
+	public final int secondsBetween;
 
-    public Warning(T type, int lineNumber, Date warningCreationTime, int secondsBetween) {
-        this.type = type;
-        this.warningCreationTime = warningCreationTime;
-        this.secondsBetween = secondsBetween;
-        this.lineNumber = lineNumber;
-    }
+	public Warning(int docLineNumber, T type, int lineNumber, Date warningCreationTime) {
+		this(docLineNumber, type, lineNumber, warningCreationTime, -1);
+	}
+
+	public Warning(int docLineNumber, T type, int lineNumber, Date warningCreationTime, int secondsBetween) {
+		this.docLineNumber = docLineNumber;
+		this.type = type;
+		this.warningCreationTime = warningCreationTime;
+		this.secondsBetween = secondsBetween;
+		this.lineNumber = lineNumber;
+	}
 }

--- a/eclipse/plugin/src/nl/tudelft/watchdog/eclipse/logic/ui/listeners/staticanalysis/MarkerBackTrackingAlgorithm.java
+++ b/eclipse/plugin/src/nl/tudelft/watchdog/eclipse/logic/ui/listeners/staticanalysis/MarkerBackTrackingAlgorithm.java
@@ -76,7 +76,7 @@ class MarkerBackTrackingAlgorithm {
         } else if (column > 0 && (row == 0 || memoization[row][column - 1] >= memoization[row - 1][column])) {
             MarkerHolder warning = currentMarkers.get(column - 1);
 
-            this.createdWarningTypes.add(new Warning<>(warning.message, warning.lineNumber, DateTime.now().toDate()));
+            this.createdWarningTypes.add(new Warning<>(-1, warning.message, warning.lineNumber, DateTime.now().toDate()));
 
             traverseMemoizationTable(row, column - 1);
         // In this case, the row length is lower, which means that the oldMarkers was longer at this point
@@ -85,7 +85,7 @@ class MarkerBackTrackingAlgorithm {
             MarkerHolder warning = oldMarkers.get(row - 1);
             DateTime now = DateTime.now();
 
-            this.removedWarningTypes.add(new Warning<>(warning.message, warning.lineNumber, now.toDate(), Seconds.secondsBetween(warning.warningCreationTime, now).getSeconds()));
+            this.removedWarningTypes.add(new Warning<>(-1, warning.message, warning.lineNumber, now.toDate(), Seconds.secondsBetween(warning.warningCreationTime, now).getSeconds()));
 
             traverseMemoizationTable(row - 1, column);
         }

--- a/eclipse/plugin/src/nl/tudelft/watchdog/eclipse/logic/ui/listeners/staticanalysis/ResourceAndResourceDeltaVisitor.java
+++ b/eclipse/plugin/src/nl/tudelft/watchdog/eclipse/logic/ui/listeners/staticanalysis/ResourceAndResourceDeltaVisitor.java
@@ -122,7 +122,7 @@ public class ResourceAndResourceDeltaVisitor implements IResourceDeltaVisitor, I
 
 	private Warning<String> createWarning(Warning<String> warning) {
 		return new Warning<>(
-				warning.docLineNumber,
+				warning.docTotalLines,
 				StaticAnalysisMessageClassifier.classify(warning.type),
 				warning.lineNumber,
 				warning.warningCreationTime,

--- a/intellij/src/nl/tudelft/watchdog/intellij/logic/ui/listeners/staticanalysis/IntelliJMarkupModelListener.java
+++ b/intellij/src/nl/tudelft/watchdog/intellij/logic/ui/listeners/staticanalysis/IntelliJMarkupModelListener.java
@@ -37,209 +37,210 @@ import static nl.tudelft.watchdog.core.logic.ui.listeners.staticanalysis.StaticA
 
 public class IntelliJMarkupModelListener extends CoreMarkupModelListener implements MarkupModelListener, Disposable {
 
-    static {
-        IDE_BUNDLE.createPatternsForKeysInBundle("messages.InspectionsBundle");
-        IDE_BUNDLE.createPatternsForKeysInBundle("com.siyeh.InspectionGadgetsBundle");
+	static {
+		IDE_BUNDLE.createPatternsForKeysInBundle("messages.InspectionsBundle");
+		IDE_BUNDLE.createPatternsForKeysInBundle("com.siyeh.InspectionGadgetsBundle");
 
-        IDE_BUNDLE.sortList();
-    }
+		IDE_BUNDLE.sortList();
+	}
 
-    private final Document document;
-    private final TrackingEventManager trackingEventManager;
-    private final com.intellij.openapi.editor.Document intellijDocument;
+	private final Document document;
+	private final TrackingEventManager trackingEventManager;
+	private final com.intellij.openapi.editor.Document intellijDocument;
 
-    private final Set<Warning<RangeHighlighterEx>> generatedWarnings;
-    private final Set<Warning<RangeHighlighterEx>> warnings;
-    private final Map<RangeHighlighterEx, DateTime> timeMapping;
+	private final Set<Warning<RangeHighlighterEx>> generatedWarnings;
+	private final Set<Warning<RangeHighlighterEx>> warnings;
+	private final Map<RangeHighlighterEx, DateTime> timeMapping;
 
-    private IntelliJMarkupModelListener(Document document, TrackingEventManager trackingEventManager, com.intellij.openapi.editor.Document intellijDocument) {
-        this.document = document;
-        this.trackingEventManager = trackingEventManager;
-        this.intellijDocument = intellijDocument;
+	private IntelliJMarkupModelListener(Document document, TrackingEventManager trackingEventManager, com.intellij.openapi.editor.Document intellijDocument) {
+		this.document = document;
+		this.trackingEventManager = trackingEventManager;
+		this.intellijDocument = intellijDocument;
 
-        generatedWarnings = new HashSet<>();
-        warnings = new HashSet<>();
-        timeMapping = new WeakHashMap<>();
-    }
+		generatedWarnings = new HashSet<>();
+		warnings = new HashSet<>();
+		timeMapping = new WeakHashMap<>();
+	}
 
-    /**
-     * Create a new {@link IntelliJMarkupModelListener} for an editor. This listener is only attached after the
-     * {@link DaemonCodeAnalyzer} has finished analyzing this file.
-     *
-     * The listener is attached to the {@link com.intellij.openapi.editor.markup.MarkupModel} of the document,
-     * which contains all {@link RangeHighlighterEx}s that represent the Static Analysis warnings.
-     *
-     * @param project The project the file exists in.
-     * @param disposable The disposable to clean up the listeners and any potential {@link MessageBusConnection}.
-     * @param editor The editor of the document.
-     * @param trackingEventManager The manager that can process all the events generated.
-     * @return A newly initiated listener that will later be attached to the {@link com.intellij.openapi.editor.markup.MarkupModel} of the document
-     */
-    public static IntelliJMarkupModelListener initializeAfterAnalysisFinished(
-            Project project, Disposable disposable, Editor editor, TrackingEventManager trackingEventManager) {
+	/**
+	 * Create a new {@link IntelliJMarkupModelListener} for an editor. This listener is only attached after the
+	 * {@link DaemonCodeAnalyzer} has finished analyzing this file.
+	 *
+	 * The listener is attached to the {@link com.intellij.openapi.editor.markup.MarkupModel} of the document,
+	 * which contains all {@link RangeHighlighterEx}s that represent the Static Analysis warnings.
+	 *
+	 * @param project The project the file exists in.
+	 * @param disposable The disposable to clean up the listeners and any potential {@link MessageBusConnection}.
+	 * @param editor The editor of the document.
+	 * @param trackingEventManager The manager that can process all the events generated.
+	 * @return A newly initiated listener that will later be attached to the {@link com.intellij.openapi.editor.markup.MarkupModel} of the document
+	 */
+	public static IntelliJMarkupModelListener initializeAfterAnalysisFinished(
+			Project project, Disposable disposable, Editor editor, TrackingEventManager trackingEventManager) {
 
-        final com.intellij.openapi.editor.Document intellijDocument = editor.getDocument();
-        final IntelliJMarkupModelListener markupModelListener = new IntelliJMarkupModelListener(DocumentCreator.createDocument(editor), trackingEventManager, intellijDocument);
+		final com.intellij.openapi.editor.Document intellijDocument = editor.getDocument();
+		final IntelliJMarkupModelListener markupModelListener = new IntelliJMarkupModelListener(DocumentCreator.createDocument(editor), trackingEventManager, intellijDocument);
 
-        // We need to run this in smart mode, because the very first time you start your editor, it is very briefly
-        // in dumb mode and the codeAnalyzer thinks (incorrectly) it is  finished.
-        // Therefore, wait for smart mode and only then start listening, to make sure the codeAnalyzer actually did its thing.
-        // For more information see https://www.jetbrains.org/intellij/sdk/docs/basics/indexing_and_psi_stubs.html
-        DumbServiceImpl.getInstance(project).runWhenSmart(() -> {
-            // In the case that the analyzer finished after a file was closed just after opening the IDE,
-            // do not try to attach any other listeners. These listeners would fail, as the editor no longer exists.
-            if (Disposer.isDisposed(disposable)) {
-                return;
-            }
+		// We need to run this in smart mode, because the very first time you start your editor, it is very briefly
+		// in dumb mode and the codeAnalyzer thinks (incorrectly) it is  finished.
+		// Therefore, wait for smart mode and only then start listening, to make sure the codeAnalyzer actually did its thing.
+		// For more information see https://www.jetbrains.org/intellij/sdk/docs/basics/indexing_and_psi_stubs.html
+		DumbServiceImpl.getInstance(project).runWhenSmart(() -> {
+			// In the case that the analyzer finished after a file was closed just after opening the IDE,
+			// do not try to attach any other listeners. These listeners would fail, as the editor no longer exists.
+			if (Disposer.isDisposed(disposable)) {
+				return;
+			}
 
-            final DaemonCodeAnalyzerImpl analyzer = (DaemonCodeAnalyzerImpl) DaemonCodeAnalyzer.getInstance(project);
-            final MessageBusConnection codeAnalyzerMessageBusConnection = project.getMessageBus().connect(disposable);
-            final MessageBusConnection documentMessageBusConnection = project.getMessageBus().connect(disposable);
+			final DaemonCodeAnalyzerImpl analyzer = (DaemonCodeAnalyzerImpl) DaemonCodeAnalyzer.getInstance(project);
+			final MessageBusConnection codeAnalyzerMessageBusConnection = project.getMessageBus().connect(disposable);
+			final MessageBusConnection documentMessageBusConnection = project.getMessageBus().connect(disposable);
 
-            codeAnalyzerMessageBusConnection.subscribe(DaemonCodeAnalyzer.DAEMON_EVENT_TOPIC, new DaemonCodeAnalyzer.DaemonListenerAdapter() {
-                @Override
-                public void daemonFinished() {
-                    // We only receive global Code Analyzer events. This means that once such an event triggered,
-                    // we do not know for which file the analysis actually succeeded. Therefore we need to check
-                    // the so-called "dirty" state of the file for this particular analyzer to check whether
-                    // the analyzer actually finished. In this case, `null` indicates: the file is not dirty.
-                    if (analyzer.getFileStatusMap().getFileDirtyScope(intellijDocument, Pass.UPDATE_ALL) == null) {
-                        final MarkupModelImpl markupModel = (MarkupModelImpl) DocumentMarkupModel.forDocument(intellijDocument, project, true);
+			codeAnalyzerMessageBusConnection.subscribe(DaemonCodeAnalyzer.DAEMON_EVENT_TOPIC, new DaemonCodeAnalyzer.DaemonListenerAdapter() {
+				@Override
+				public void daemonFinished() {
+					// We only receive global Code Analyzer events. This means that once such an event triggered,
+					// we do not know for which file the analysis actually succeeded. Therefore we need to check
+					// the so-called "dirty" state of the file for this particular analyzer to check whether
+					// the analyzer actually finished. In this case, `null` indicates: the file is not dirty.
+					if (analyzer.getFileStatusMap().getFileDirtyScope(intellijDocument, Pass.UPDATE_ALL) == null) {
+						final MarkupModelImpl markupModel = (MarkupModelImpl) DocumentMarkupModel.forDocument(intellijDocument, project, true);
 
-                        markupModelListener.processWarningSnapshot(markupModel.getAllHighlighters());
-                        markupModel.addMarkupModelListener(disposable, markupModelListener);
+						markupModelListener.processWarningSnapshot(markupModel.getAllHighlighters());
+						markupModel.addMarkupModelListener(disposable, markupModelListener);
 
-                        // We batch up changes and only transfer them on every save. This is in-line with the Eclipse
-                        // interface, which only exposes listeners for `POST_BUILD`. Therefore, cache all warnings in
-                        // {@link IntelliJMarkupModelListener#generatedWarnings} and {@link IntelliJMarkupModelListener#warnings}
-                        // and flush these warnings after the fact.
-                        documentMessageBusConnection.subscribe(AppTopics.FILE_DOCUMENT_SYNC, new FileDocumentManagerAdapter() {
-                            @Override
-                            public void beforeDocumentSaving(@NotNull com.intellij.openapi.editor.Document savedDocument) {
-                                if (intellijDocument.equals(savedDocument)) {
-                                    markupModelListener.flushForDocument();
-                                }
-                            }
-                        });
-                        codeAnalyzerMessageBusConnection.disconnect();
-                    }
-                }
-            });
-        });
+						// We batch up changes and only transfer them on every save. This is in-line with the Eclipse
+						// interface, which only exposes listeners for `POST_BUILD`. Therefore, cache all warnings in
+						// {@link IntelliJMarkupModelListener#generatedWarnings} and {@link IntelliJMarkupModelListener#warnings}
+						// and flush these warnings after the fact.
+						documentMessageBusConnection.subscribe(AppTopics.FILE_DOCUMENT_SYNC, new FileDocumentManagerAdapter() {
+							@Override
+							public void beforeDocumentSaving(@NotNull com.intellij.openapi.editor.Document savedDocument) {
+								if (intellijDocument.equals(savedDocument)) {
+									markupModelListener.flushForDocument();
+								}
+							}
+						});
+						codeAnalyzerMessageBusConnection.disconnect();
+					}
+				}
+			});
+		});
 
-        return markupModelListener;
-    }
+		return markupModelListener;
+	}
 
-    private void processWarningSnapshot(RangeHighlighter[] highlighters) {
-        if (highlighters.length == 0) {
-            return;
-        }
+	private void processWarningSnapshot(RangeHighlighter[] highlighters) {
+		if (highlighters.length == 0) {
+			return;
+		}
 
-        // markupModel.getAllHighlighters returns a list of RangeHighlighter,
-        // even though we know they are all instances of RangeHighlighterEx.
-        // Therefore do an instanceof check and then explicitly cast them
-        // to use them in the other methods
-        final Stream<RangeHighlighterEx> rangeHighlighters = Arrays.stream(highlighters)
-                .filter(RangeHighlighterEx.class::isInstance)
-                .map(RangeHighlighterEx.class::cast);
+		// markupModel.getAllHighlighters returns a list of RangeHighlighter,
+		// even though we know they are all instances of RangeHighlighterEx.
+		// Therefore do an instanceof check and then explicitly cast them
+		// to use them in the other methods
+		final Stream<RangeHighlighterEx> rangeHighlighters = Arrays.stream(highlighters)
+				.filter(RangeHighlighterEx.class::isInstance)
+				.map(RangeHighlighterEx.class::cast);
 
-        final List<Warning<String>> warnings = rangeHighlighters
-                .filter(IntelliJMarkupModelListener::isWarningRangeHighlighter)
-                .map(rangeHighlighter -> createWarningFromRangeHighlighter(rangeHighlighter, null))
-                .map(IntelliJMarkupModelListener::classifyWarning)
-                .collect(Collectors.toList());
+		final List<Warning<String>> warnings = rangeHighlighters
+				.filter(IntelliJMarkupModelListener::isWarningRangeHighlighter)
+				.map(rangeHighlighter -> createWarningFromRangeHighlighter(rangeHighlighter, null))
+				.map(IntelliJMarkupModelListener::classifyWarning)
+				.collect(Collectors.toList());
 
-        this.trackingEventManager.addEvent(new FileWarningSnapshotEvent(this.document.prepareDocument(), warnings));
-    }
+		this.trackingEventManager.addEvent(new FileWarningSnapshotEvent(this.document.prepareDocument(), warnings));
+	}
 
-    private void flushForDocument() {
-        addCreatedWarnings(this.trackingEventManager, this.generatedWarnings.stream().map(IntelliJMarkupModelListener::classifyWarning), this.document);
-        this.generatedWarnings.clear();
+	private void flushForDocument() {
+		addCreatedWarnings(this.trackingEventManager, this.generatedWarnings.stream().map(IntelliJMarkupModelListener::classifyWarning), this.document);
+		this.generatedWarnings.clear();
 
-        addRemovedWarnings(this.trackingEventManager, this.warnings.stream().map(IntelliJMarkupModelListener::classifyWarning), this.document);
-        this.warnings.clear();
-    }
+		addRemovedWarnings(this.trackingEventManager, this.warnings.stream().map(IntelliJMarkupModelListener::classifyWarning), this.document);
+		this.warnings.clear();
+	}
 
-    @Override
-    public void afterAdded(@NotNull RangeHighlighterEx rangeHighlighterEx) {
-        if (isWarningRangeHighlighter(rangeHighlighterEx)) {
-            final DateTime creationTime = DateTime.now();
+	@Override
+	public void afterAdded(@NotNull RangeHighlighterEx rangeHighlighterEx) {
+		if (isWarningRangeHighlighter(rangeHighlighterEx)) {
+			final DateTime creationTime = DateTime.now();
 
-            this.timeMapping.put(rangeHighlighterEx, creationTime);
-            this.generatedWarnings.add(new Warning<>(rangeHighlighterEx, getLineNumberForHighlighter(rangeHighlighterEx), creationTime.toDate()));
-        }
-    }
+			this.timeMapping.put(rangeHighlighterEx, creationTime);
+			this.generatedWarnings.add(new Warning<>(intellijDocument.getLineCount(), rangeHighlighterEx, getLineNumberForHighlighter(rangeHighlighterEx), creationTime.toDate()));
+		}
+	}
 
-    @Override
-    public void beforeRemoved(@NotNull RangeHighlighterEx rangeHighlighterEx) {
-        DateTime creationTime = this.timeMapping.remove(rangeHighlighterEx);
+	@Override
+	public void beforeRemoved(@NotNull RangeHighlighterEx rangeHighlighterEx) {
+		DateTime creationTime = this.timeMapping.remove(rangeHighlighterEx);
 
-        if (isWarningRangeHighlighter(rangeHighlighterEx)) {
-            // Only process a deletion if we hadn't encountered this marker in this session before.
-            // If we did encounter it, remove returns `true` and the warning is not saved as removed.
-            if (!this.generatedWarnings.removeIf(warning -> warning.type.equals(rangeHighlighterEx))) {
-                this.warnings.add(createWarningFromRangeHighlighter(rangeHighlighterEx, creationTime));
-            }
-        }
-    }
+		if (isWarningRangeHighlighter(rangeHighlighterEx)) {
+			// Only process a deletion if we hadn't encountered this marker in this session before.
+			// If we did encounter it, remove returns `true` and the warning is not saved as removed.
+			if (!this.generatedWarnings.removeIf(warning -> warning.type.equals(rangeHighlighterEx))) {
+				this.warnings.add(createWarningFromRangeHighlighter(rangeHighlighterEx, creationTime));
+			}
+		}
+	}
 
-    @Override
-    public void attributesChanged(@NotNull RangeHighlighterEx rangeHighlighterEx, boolean b, boolean b1) {
-        // Unused for now.
-    }
+	@Override
+	public void attributesChanged(@NotNull RangeHighlighterEx rangeHighlighterEx, boolean b, boolean b1) {
+		// Unused for now.
+	}
 
-    @Override
-    public void dispose() {
-        // We store no internal state ourselves.
-    }
+	@Override
+	public void dispose() {
+		// We store no internal state ourselves.
+	}
 
-    private static boolean isWarningRangeHighlighter(@NotNull RangeHighlighterEx rangeHighlighterEx) {
-        return rangeHighlighterEx.getLayer() == HighlighterLayer.WARNING;
-    }
+	private static boolean isWarningRangeHighlighter(@NotNull RangeHighlighterEx rangeHighlighterEx) {
+		return rangeHighlighterEx.getLayer() == HighlighterLayer.WARNING;
+	}
 
-    @NotNull
-    private Warning<RangeHighlighterEx> createWarningFromRangeHighlighter(@NotNull RangeHighlighterEx rangeHighlighterEx, DateTime creationTime) {
-        final DateTime now = DateTime.now();
+	@NotNull
+	private Warning<RangeHighlighterEx> createWarningFromRangeHighlighter(@NotNull RangeHighlighterEx rangeHighlighterEx, DateTime creationTime) {
+		final DateTime now = DateTime.now();
 
-        int seconds;
+		int seconds;
 
-        if (creationTime == null) {
-            seconds = -1;
-        } else {
-            seconds = Seconds.secondsBetween(creationTime, now).getSeconds();
-        }
+		if (creationTime == null) {
+			seconds = -1;
+		} else {
+			seconds = Seconds.secondsBetween(creationTime, now).getSeconds();
+		}
 
-        return new Warning<>(
-                rangeHighlighterEx,
-                getLineNumberForHighlighter(rangeHighlighterEx),
-                now.toDate(),
-                seconds
-        );
-    }
+		return new Warning<>(
+				intellijDocument.getLineCount(),
+				rangeHighlighterEx,
+				getLineNumberForHighlighter(rangeHighlighterEx),
+				now.toDate(),
+				seconds
+		);
+	}
 
-    private int getLineNumberForHighlighter(RangeHighlighterEx warning) {
-        try {
-            return intellijDocument.getLineNumber(warning.getAffectedAreaStartOffset());
-            // It could be that IntelliJ already synced the document before generating the
-            // "beforeRemoved" event. Therefore, catch these errors and set to -1 as we have
-            // no clue what the actual line number was.
-        } catch (IndexOutOfBoundsException ignored) {
-            return -1;
-        }
-    }
+	private int getLineNumberForHighlighter(RangeHighlighterEx warning) {
+		try {
+			return intellijDocument.getLineNumber(warning.getAffectedAreaStartOffset());
+			// It could be that IntelliJ already synced the document before generating the
+			// "beforeRemoved" event. Therefore, catch these errors and set to -1 as we have
+			// no clue what the actual line number was.
+		} catch (IndexOutOfBoundsException ignored) {
+			return -1;
+		}
+	}
 
-    private static Warning<String> classifyWarning(Warning<RangeHighlighterEx> warning) {
-        return new Warning<>(classifyWarningTypeFromHighlighter(warning.type), warning.lineNumber, warning.warningCreationTime, warning.secondsBetween);
-    }
+	private static Warning<String> classifyWarning(Warning<RangeHighlighterEx> warning) {
+		return new Warning<>(warning.docLineNumber, classifyWarningTypeFromHighlighter(warning.type), warning.lineNumber, warning.warningCreationTime, warning.secondsBetween);
+	}
 
-    @NotNull
-    private static String classifyWarningTypeFromHighlighter(@NotNull RangeHighlighterEx rangeHighlighterEx) {
-        final Object errorStripeTooltip = rangeHighlighterEx.getErrorStripeTooltip();
+	@NotNull
+	private static String classifyWarningTypeFromHighlighter(@NotNull RangeHighlighterEx rangeHighlighterEx) {
+		final Object errorStripeTooltip = rangeHighlighterEx.getErrorStripeTooltip();
 
-        if (errorStripeTooltip instanceof HighlightInfo) {
-            return StaticAnalysisMessageClassifier.classify(((HighlightInfo) errorStripeTooltip).getDescription());
-        }
+		if (errorStripeTooltip instanceof HighlightInfo) {
+			return StaticAnalysisMessageClassifier.classify(((HighlightInfo) errorStripeTooltip).getDescription());
+		}
 
-        return "unknown";
-    }
+		return "unknown";
+	}
 }


### PR DESCRIPTION
In IntelliJ, the timing of the warning creation is different compared to the moment of `Document` parsing. The Document statistics are only obtained at the moment of transferring the information, e.g. when the file is saved in IntelliJ. However, the total number of line numbers in a file can be changed in the mean time. 

For example, a warning event can be generated on line 70 with the document having 72 lines, but then the developer deletes 6 lines. At this point, the full document has 66 lines, while the warning reports it was on line 70. Instead of having both 70 and 66, we should have 70 and 72 to make sure we capture the correct information.

To that end, call `intelliJDocument.getLineCount()` whenever we process a warning, to store this information prematurely and correctly.

I have also fixed the indentation of all files I touched at the same time, to unify the indentation per file one at a time :smile: 