### PR TITLE
Fix compilation failure in IntelliJ

### DIFF
--- a/intellij/src/nl/tudelft/watchdog/intellij/logic/ui/listeners/staticanalysis/IntelliJMarkupModelListener.java
+++ b/intellij/src/nl/tudelft/watchdog/intellij/logic/ui/listeners/staticanalysis/IntelliJMarkupModelListener.java
@@ -230,7 +230,7 @@ public class IntelliJMarkupModelListener extends CoreMarkupModelListener impleme
 	}
 
 	private static Warning<String> classifyWarning(Warning<RangeHighlighterEx> warning) {
-		return new Warning<>(warning.docLineNumber, classifyWarningTypeFromHighlighter(warning.type), warning.lineNumber, warning.warningCreationTime, warning.secondsBetween);
+		return new Warning<>(warning.docTotalLines, classifyWarningTypeFromHighlighter(warning.type), warning.lineNumber, warning.warningCreationTime, warning.secondsBetween);
 	}
 
 	@NotNull


### PR DESCRIPTION
#310 inadvertently broke the compilation in IntelliJ, which for some reason my local `mvn compile` did not catch. Rename the field access to fix that.